### PR TITLE
Docker Compose (MySQL + Backend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=mysql+pymysql://app:app@db:3306/pipelet_sandbox

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 venv/
 .env
 .env.*
+!.env.example
 .envrc
 .pytest_cache/
 .coverage

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend /app
+EXPOSE 5000 9000
+CMD ["python","wsgi.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.9"
+services:
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_DATABASE: pipelet_sandbox
+      MYSQL_USER: app
+      MYSQL_PASSWORD: app
+      MYSQL_ROOT_PASSWORD: root
+    command: ["--default-authentication-plugin=mysql_native_password"]
+    ports: ["3306:3306"]
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ppassword"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - db_data:/var/lib/mysql
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: ../Dockerfile.backend
+    env_file: .env
+    environment:
+      FLASK_ENV: development
+      DATABASE_URL: ${DATABASE_URL}
+    depends_on:
+      - db
+    ports:
+      - "5000:5000"   # Flask API
+      - "9000:9000"   # OCPP WS (später genutzt)
+    command: ["python", "wsgi.py"]
+
+volumes:
+  db_data:

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,0 +1,14 @@
+# Lokale Entwicklung mit Docker
+
+1. `.env` anlegen:
+   ```bash
+   cp .env.example .env
+   ```
+2. Container starten:
+   ```bash
+   docker compose up --build
+   ```
+3. Healthcheck aufrufen:
+   ```bash
+   curl http://localhost:5000/api/health
+   ```


### PR DESCRIPTION
## Summary
- add docker compose setup to run a MySQL 8 database and the Flask backend together
- add backend Dockerfile and sample environment configuration
- document the local docker-based development flow

## Testing
- not run (infrastructure setup only)


------
https://chatgpt.com/codex/tasks/task_e_68d148baf39c8322bf07cbc0b8240ff6