### PR TITLE
OCPP Central System + Simulator + Logs

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,8 +3,11 @@
 from flask import Flask
 
 from .api.health import bp as health_bp
+from .api.logs import bp as logs_bp
+from .api.sim import bp as sim_bp
 from .config import Config
 from .extensions import cors, db
+from .ocpp.server import ensure_server_started
 
 
 def create_app(config_class: type[Config] = Config) -> Flask:
@@ -18,11 +21,15 @@ def create_app(config_class: type[Config] = Config) -> Flask:
         cors.init_app(app)
 
     app.register_blueprint(health_bp, url_prefix="/api")
+    app.register_blueprint(logs_bp, url_prefix="/api")
+    app.register_blueprint(sim_bp, url_prefix="/api")
 
     with app.app_context():
         # Import models to ensure they are registered with SQLAlchemy before creating tables.
         from .models import logs, pipelet, workflow  # noqa: F401
 
         db.create_all()
+
+    ensure_server_started(app)
 
     return app

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -1,0 +1,37 @@
+"""API endpoint exposing run log entries."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from flask import Blueprint, jsonify, request
+
+from ..models.logs import RunLog
+
+bp = Blueprint("logs", __name__)
+
+
+@bp.get("/logs")
+def get_logs() -> tuple[object, int]:
+    source = request.args.get("source")
+    limit = request.args.get("limit", type=int) or 200
+    limit = max(1, min(limit, 200))
+
+    query = RunLog.query
+    if source:
+        query = query.filter_by(source=source)
+
+    entries = (
+        query.order_by(RunLog.created_at.desc()).limit(limit).all()
+    )
+
+    data = [
+        {
+            "id": entry.id,
+            "source": entry.source,
+            "message": entry.message,
+            "createdAt": entry.created_at.isoformat() + "Z",
+        }
+        for entry in entries
+    ]
+    return jsonify(data), HTTPStatus.OK

--- a/backend/app/api/sim.py
+++ b/backend/app/api/sim.py
@@ -1,0 +1,91 @@
+"""REST triggers for the OCPP charge point simulator."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from flask import Blueprint, current_app, jsonify, request
+
+from ..ocpp.simulator import SimulatorState, get_simulator
+
+bp = Blueprint("sim", __name__)
+
+
+def _serialize_state(state: SimulatorState) -> dict[str, object]:
+    return {
+        "interval": state.interval,
+        "transactionId": state.transaction_id,
+    }
+
+
+def _json_error(message: str, status: HTTPStatus = HTTPStatus.BAD_REQUEST):
+    return jsonify({"error": message}), status
+
+
+@bp.post("/sim/connect")
+def connect() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    try:
+        state = simulator.connect()
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Simulator connect failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_state(state)), HTTPStatus.OK
+
+
+@bp.post("/sim/heartbeat/start")
+def start_heartbeat() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    try:
+        state = simulator.start_heartbeat()
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Heartbeat start failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_state(state)), HTTPStatus.OK
+
+
+def _require_id_tag() -> str:
+    payload = request.get_json(silent=True) or {}
+    id_tag = payload.get("idTag")
+    if not isinstance(id_tag, str) or not id_tag:
+        raise ValueError("idTag is required")
+    return id_tag
+
+
+@bp.post("/sim/rfid")
+def authorize() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    try:
+        id_tag = _require_id_tag()
+        state = simulator.authorize(id_tag)
+    except ValueError as exc:
+        return _json_error(str(exc))
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Authorize failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_state(state)), HTTPStatus.OK
+
+
+@bp.post("/sim/start")
+def start_transaction() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    try:
+        id_tag = _require_id_tag()
+        state = simulator.start_transaction(id_tag)
+    except ValueError as exc:
+        return _json_error(str(exc))
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Start transaction failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_state(state)), HTTPStatus.OK
+
+
+@bp.post("/sim/stop")
+def stop_transaction() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    try:
+        state = simulator.stop_transaction()
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Stop transaction failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_state(state)), HTTPStatus.OK

--- a/backend/app/ocpp/__init__.py
+++ b/backend/app/ocpp/__init__.py
@@ -1,0 +1,6 @@
+"""OCPP server and simulator utilities."""
+
+from .server import ensure_server_started
+from .simulator import get_simulator
+
+__all__ = ["ensure_server_started", "get_simulator"]

--- a/backend/app/ocpp/logging.py
+++ b/backend/app/ocpp/logging.py
@@ -1,0 +1,34 @@
+"""Utility helpers for persisting OCPP related logs."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from flask import Flask
+
+from ..extensions import db
+from ..models.logs import RunLog
+
+
+def persist_run_log(app: Flask, source: str, message: str) -> None:
+    """Persist a run log entry without raising exceptions."""
+    if not message:
+        return
+
+    def _log() -> None:
+        entry = RunLog(source=source, message=message)
+        db.session.add(entry)
+        db.session.commit()
+
+    _run_in_app_context(app, _log)
+
+
+def _run_in_app_context(app: Flask, func: Callable[[], None]) -> None:
+    try:
+        with app.app_context():
+            func()
+    except Exception:  # pragma: no cover - defensive logging helper
+        # Logging to stdout/stderr is acceptable fallback.
+        app.logger.exception("Failed to persist run log entry")
+        with app.app_context():
+            db.session.rollback()

--- a/backend/app/ocpp/server.py
+++ b/backend/app/ocpp/server.py
@@ -1,0 +1,198 @@
+"""Async OCPP central system server implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import threading
+from datetime import UTC, datetime
+
+import websockets
+from flask import Flask
+from ocpp.routing import on
+from ocpp.v16 import ChargePoint as OcppChargePoint
+from ocpp.v16 import call_result
+from ocpp.v16.datatypes import IdTagInfo
+from ocpp.v16.enums import Action, AuthorizationStatus, RegistrationStatus
+from websockets.exceptions import ConnectionClosed
+from websockets.server import WebSocketServerProtocol
+
+from .logging import persist_run_log
+
+OCPP_SUBPROTOCOL = "ocpp1.6"
+
+
+class LoggingWebSocket:
+    """Proxy object around a websocket connection to persist raw frames."""
+
+    def __init__(self, websocket: WebSocketServerProtocol, app: Flask, source: str):
+        self._websocket = websocket
+        self._app = app
+        self._source = source
+
+    async def send(self, message: str) -> None:
+        persist_run_log(self._app, self._source, f"send: {message}")
+        await self._websocket.send(message)
+
+    async def recv(self) -> str:
+        message = await self._websocket.recv()
+        persist_run_log(self._app, self._source, f"recv: {message}")
+        return message
+
+    async def close(self, *args, **kwargs) -> None:  # pragma: no cover - passthrough
+        await self._websocket.close(*args, **kwargs)
+
+    def __getattr__(self, item: str) -> object:  # pragma: no cover - passthrough
+        return getattr(self._websocket, item)
+
+
+class CentralSystemChargePoint(OcppChargePoint):
+    """Charge point handler hosted by the central system."""
+
+    def __init__(
+        self,
+        cp_id: str,
+        connection: LoggingWebSocket,
+        server: CentralSystemServer,
+    ) -> None:
+        super().__init__(cp_id, connection)
+        self._server = server
+
+    async def start(self) -> None:  # pragma: no cover - exercised via integration tests
+        while True:
+            try:
+                message = await self._connection.recv()
+            except ConnectionClosed:
+                break
+            try:
+                await self.route_message(message)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                persist_run_log(
+                    self._server.app,
+                    "cs",
+                    f"error handling message from {self.id}: {exc}",
+                )
+        # Connection closed is logged by the server after the handler exits.
+
+    @on(Action.boot_notification)
+    async def on_boot_notification(  # type: ignore[override]
+        self,
+        charge_point_model: str,
+        charge_point_vendor: str,
+        **payload: object,
+    ) -> call_result.BootNotification:
+        current_time = datetime.now(UTC).isoformat()
+        return call_result.BootNotification(
+            current_time=current_time,
+            interval=10,
+            status=RegistrationStatus.accepted,
+        )
+
+    @on(Action.heartbeat)
+    async def on_heartbeat(self) -> call_result.Heartbeat:  # type: ignore[override]
+        current_time = datetime.now(UTC).isoformat()
+        return call_result.Heartbeat(current_time=current_time)
+
+    @on(Action.authorize)
+    async def on_authorize(  # type: ignore[override]
+        self, id_tag: str
+    ) -> call_result.Authorize:
+        id_tag_info = IdTagInfo(status=AuthorizationStatus.accepted)
+        return call_result.Authorize(id_tag_info=id_tag_info)
+
+    @on(Action.start_transaction)
+    async def on_start_transaction(  # type: ignore[override]
+        self,
+        connector_id: int,
+        id_tag: str,
+        meter_start: int,
+        timestamp: str,
+        **payload: object,
+    ) -> call_result.StartTransaction:
+        transaction_id = self._server.next_transaction_id()
+        id_tag_info = IdTagInfo(status=AuthorizationStatus.accepted)
+        return call_result.StartTransaction(
+            transaction_id=transaction_id,
+            id_tag_info=id_tag_info,
+        )
+
+    @on(Action.stop_transaction)
+    async def on_stop_transaction(  # type: ignore[override]
+        self,
+        meter_stop: int,
+        timestamp: str,
+        transaction_id: int,
+        **payload: object,
+    ) -> call_result.StopTransaction:
+        id_tag_info = IdTagInfo(status=AuthorizationStatus.accepted)
+        return call_result.StopTransaction(id_tag_info=id_tag_info)
+
+
+class CentralSystemServer:
+    """Manages the OCPP central system server lifecycle."""
+
+    def __init__(self, app: Flask) -> None:
+        self.app = app
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._transaction_ids = itertools.count(1)
+        self._server: websockets.server.Serve | None = None
+
+    def start(self) -> None:
+        if self._thread.is_alive():
+            return
+        self._thread.start()
+        future = asyncio.run_coroutine_threadsafe(self._start_server(), self._loop)
+        future.result(timeout=5)
+
+    def next_transaction_id(self) -> int:
+        return next(self._transaction_ids)
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    async def _start_server(self) -> None:
+        self._server = await websockets.serve(
+            self._on_connect,
+            host="0.0.0.0",
+            port=9000,
+            subprotocols=[OCPP_SUBPROTOCOL],
+        )
+
+    async def _on_connect(self, websocket: WebSocketServerProtocol, path: str) -> None:
+        cp_id = _extract_cp_id(path)
+        if cp_id is None:
+            await websocket.close(code=4000, reason="Invalid charge point id")
+            return
+        logging_ws = LoggingWebSocket(websocket, self.app, "cs")
+        persist_run_log(self.app, "cs", f"connection established with {cp_id}")
+        charge_point = CentralSystemChargePoint(cp_id, logging_ws, self)
+        try:
+            await charge_point.start()
+        finally:
+            persist_run_log(self.app, "cs", f"connection closed with {cp_id}")
+
+
+_server_instance: CentralSystemServer | None = None
+_server_lock = threading.Lock()
+
+
+def ensure_server_started(app: Flask) -> CentralSystemServer:
+    """Ensure the central system server is running for the given Flask app."""
+    global _server_instance
+    with _server_lock:
+        if _server_instance is None:
+            _server_instance = CentralSystemServer(app)
+            _server_instance.start()
+    return _server_instance
+
+
+def _extract_cp_id(path: str) -> str | None:
+    if not path:
+        return None
+    # Expected format: /CP_<id>
+    candidate = path.strip("/")
+    if not candidate.startswith("CP_"):
+        return None
+    return candidate

--- a/backend/app/ocpp/simulator.py
+++ b/backend/app/ocpp/simulator.py
@@ -1,0 +1,187 @@
+"""OCPP 1.6J charge point simulator."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import websockets
+from flask import Flask
+from ocpp.v16 import ChargePoint as OcppChargePoint
+from ocpp.v16 import call
+from websockets.exceptions import ConnectionClosed
+
+from .logging import persist_run_log
+from .server import OCPP_SUBPROTOCOL, LoggingWebSocket
+
+
+@dataclass
+class SimulatorState:
+    """State snapshot returned to REST handlers."""
+
+    interval: int
+    transaction_id: int | None
+
+
+class SimulatorChargePoint(OcppChargePoint):
+    """Charge point implementation for the simulator."""
+
+    def __init__(self, cp_id: str, connection: LoggingWebSocket, simulator: ChargePointSimulator) -> None:
+        super().__init__(cp_id, connection)
+        self._simulator = simulator
+
+    async def start(self) -> None:  # pragma: no cover - exercised through integration
+        while True:
+            try:
+                message = await self._connection.recv()
+            except ConnectionClosed:
+                break
+            try:
+                await self.route_message(message)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                persist_run_log(
+                    self._simulator.app,
+                    "cp",
+                    f"error handling message for {self.id}: {exc}",
+                )
+
+    async def send_boot_notification(self) -> object:
+        request = call.BootNotification(
+            charge_point_model="Simulator",
+            charge_point_vendor="Pipelet",
+        )
+        return await self.call(request)
+
+    async def send_heartbeat(self) -> object:
+        request = call.Heartbeat()
+        return await self.call(request)
+
+    async def send_authorize(self, id_tag: str) -> object:
+        request = call.Authorize(id_tag=id_tag)
+        return await self.call(request)
+
+    async def send_start_transaction(self, id_tag: str) -> object:
+        request = call.StartTransaction(
+            connector_id=1,
+            id_tag=id_tag,
+            meter_start=0,
+            timestamp=datetime.now(UTC).isoformat(),
+        )
+        return await self.call(request)
+
+    async def send_stop_transaction(self, transaction_id: int, id_tag: str | None = None) -> object:
+        request = call.StopTransaction(
+            meter_stop=10,
+            timestamp=datetime.now(UTC).isoformat(),
+            transaction_id=transaction_id,
+            id_tag=id_tag,
+        )
+        return await self.call(request)
+
+
+class ChargePointSimulator:
+    """Manage simulator lifecycle and expose synchronous helpers for REST handlers."""
+
+    def __init__(self, app: Flask) -> None:
+        self.app = app
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+        self._connection: LoggingWebSocket | None = None
+        self._charge_point: SimulatorChargePoint | None = None
+        self._receiver_task: asyncio.Task[None] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._interval: int = 10
+        self._active_transaction_id: int | None = None
+
+    def connect(self) -> SimulatorState:
+        return self._sync(self._connect())
+
+    def start_heartbeat(self) -> SimulatorState:
+        return self._sync(self._start_heartbeat())
+
+    def authorize(self, id_tag: str) -> SimulatorState:
+        return self._sync(self._authorize(id_tag))
+
+    def start_transaction(self, id_tag: str) -> SimulatorState:
+        return self._sync(self._start_transaction(id_tag))
+
+    def stop_transaction(self) -> SimulatorState:
+        return self._sync(self._stop_transaction())
+
+    def _sync(self, coro: Awaitable[SimulatorState]) -> SimulatorState:
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        result = future.result(timeout=10)
+        return result
+
+    async def _connect(self) -> SimulatorState:
+        if self._charge_point is None:
+            websocket = await websockets.connect(
+                "ws://localhost:9000/CP_1",
+                subprotocols=[OCPP_SUBPROTOCOL],
+            )
+            logging_ws = LoggingWebSocket(websocket, self.app, "cp")
+            self._connection = logging_ws
+            self._charge_point = SimulatorChargePoint("CP_1", logging_ws, self)
+            self._receiver_task = asyncio.create_task(self._charge_point.start())
+            response = await self._charge_point.send_boot_notification()
+            interval = getattr(response, "interval", 10)
+            self._interval = int(interval)
+        return SimulatorState(interval=self._interval, transaction_id=self._active_transaction_id)
+
+    async def _start_heartbeat(self) -> SimulatorState:
+        await self._ensure_connected()
+        if self._heartbeat_task is None or self._heartbeat_task.done():
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        return SimulatorState(interval=self._interval, transaction_id=self._active_transaction_id)
+
+    async def _authorize(self, id_tag: str) -> SimulatorState:
+        await self._ensure_connected()
+        await self._charge_point.send_authorize(id_tag)
+        return SimulatorState(interval=self._interval, transaction_id=self._active_transaction_id)
+
+    async def _start_transaction(self, id_tag: str) -> SimulatorState:
+        await self._ensure_connected()
+        response = await self._charge_point.send_start_transaction(id_tag)
+        transaction_id = getattr(response, "transaction_id", None)
+        if transaction_id is not None:
+            self._active_transaction_id = int(transaction_id)
+        return SimulatorState(interval=self._interval, transaction_id=self._active_transaction_id)
+
+    async def _stop_transaction(self) -> SimulatorState:
+        await self._ensure_connected()
+        if self._active_transaction_id is None:
+            raise RuntimeError("No active transaction")
+        await self._charge_point.send_stop_transaction(self._active_transaction_id)
+        self._active_transaction_id = None
+        return SimulatorState(interval=self._interval, transaction_id=None)
+
+    async def _ensure_connected(self) -> None:
+        if self._charge_point is None:
+            await self._connect()
+
+    async def _heartbeat_loop(self) -> None:  # pragma: no cover - requires integration
+        while True:
+            try:
+                await self._charge_point.send_heartbeat()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                persist_run_log(
+                    self.app,
+                    "cp",
+                    f"heartbeat failed: {exc}",
+                )
+            await asyncio.sleep(self._interval)
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+
+def get_simulator(app: Flask) -> ChargePointSimulator:
+    """Return a singleton simulator tied to the Flask app."""
+    if "cp_simulator" not in app.extensions:
+        app.extensions["cp_simulator"] = ChargePointSimulator(app)
+    return app.extensions["cp_simulator"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ pytest
 pytest-cov
 ruff
 black
+ocpp
+websockets
+asyncio


### PR DESCRIPTION
## Summary
- add an asynchronous OCPP 1.6 central system server that records all messages and responds to BootNotification, Heartbeat, Authorize, StartTransaction, and StopTransaction requests
- introduce a websocket-based charge point simulator with REST triggers for connect, heartbeat loop, RFID authorization, start, and stop flows while persisting outgoing and incoming frames to the run log
- expose a run log API endpoint, register the new blueprints, start the server during app creation, and declare the new dependencies

## Testing
- pytest
- ruff check backend

------
https://chatgpt.com/codex/tasks/task_e_68d149bdafd08322ab33e1f0130b63f0