### PR TITLE
Pipelet runtime (subprocess, timeout, tests)

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,13 +1,10 @@
 """Application factory for the Pipelet OCPP backend."""
+from __future__ import annotations
 
 from flask import Flask
 
-from .api.health import bp as health_bp
-from .api.logs import bp as logs_bp
-from .api.sim import bp as sim_bp
 from .config import Config
 from .extensions import cors, db
-from .ocpp.server import ensure_server_started
 
 
 def create_app(config_class: type[Config] = Config) -> Flask:
@@ -19,6 +16,11 @@ def create_app(config_class: type[Config] = Config) -> Flask:
 
     if cors is not None:
         cors.init_app(app)
+
+    from .api.health import bp as health_bp
+    from .api.logs import bp as logs_bp
+    from .api.sim import bp as sim_bp
+    from .ocpp.server import ensure_server_started
 
     app.register_blueprint(health_bp, url_prefix="/api")
     app.register_blueprint(logs_bp, url_prefix="/api")
@@ -33,3 +35,4 @@ def create_app(config_class: type[Config] = Config) -> Flask:
     ensure_server_started(app)
 
     return app
+

--- a/backend/app/pipelets/__init__.py
+++ b/backend/app/pipelets/__init__.py
@@ -1,0 +1,1 @@
+"""Pipelet runtime package."""

--- a/backend/app/pipelets/runtime.py
+++ b/backend/app/pipelets/runtime.py
@@ -1,0 +1,95 @@
+"""Runtime utilities for executing pipelet code in a sandboxed subprocess."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from typing import Any, Dict, Optional, Tuple
+
+from backend.app.utils import security
+
+_PIPELET_WRAPPER_TEMPLATE = """import json, sys\n""" \
+    "inp = json.loads(sys.stdin.read() or \"{}\")\n" \
+    "message = inp.get(\"message\")\n" \
+    "context = inp.get(\"context\", {})\n" \
+    "{CODE}\n" \
+    "out = run(message, context)\n" \
+    "print(json.dumps({\"result\": out}))\n"
+
+
+ResultType = Tuple[Any, str, Optional[Dict[str, Any]]]
+
+
+def _build_wrapper_source(code: str) -> str:
+    """Embed user supplied code inside the execution template."""
+    return _PIPELET_WRAPPER_TEMPLATE.replace("{CODE}", code)
+
+
+def _write_wrapper_file(code: str) -> str:
+    """Persist the wrapper code to a temporary file and return its path."""
+    wrapper_source = _build_wrapper_source(code)
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as tmp_file:
+        tmp_file.write(wrapper_source)
+        tmp_file.flush()
+        return tmp_file.name
+
+
+def _collect_error(debug: str, default_type: str = "Exception") -> Dict[str, str]:
+    error_type = "SyntaxError" if "SyntaxError" in debug else default_type
+    message = "Pipelet execution failed"
+    if debug:
+        last_line = debug.strip().splitlines()[-1]
+        if last_line:
+            message = last_line
+    return {"type": error_type, "message": message}
+
+
+def run_pipelet(
+    code: str,
+    message: Dict[str, Any],
+    context: Optional[Dict[str, Any]],
+    timeout: float = 1.5,
+) -> ResultType:
+    """Execute a pipelet definition in an isolated subprocess."""
+    context = context or {}
+    wrapper_path = _write_wrapper_file(code)
+    debug_output = ""
+    try:
+        payload = json.dumps({"message": message, "context": context})
+        preexec_fn = security.build_preexec_fn()
+        completed = subprocess.run(
+            [sys.executable, "-I", wrapper_path],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            preexec_fn=preexec_fn,
+        )
+        debug_output = completed.stderr or ""
+        if completed.returncode != 0:
+            return None, debug_output, _collect_error(debug_output)
+
+        stdout_text = completed.stdout or ""
+        try:
+            parsed = json.loads(stdout_text or "{}")
+        except json.JSONDecodeError:
+            return None, debug_output, {
+                "type": "ProtocolError",
+                "message": "Invalid JSON output from pipelet",
+            }
+        return parsed.get("result"), debug_output, None
+    except subprocess.TimeoutExpired as exc:
+        debug_output = (exc.stderr or "") if isinstance(exc.stderr, str) else ""
+        return None, debug_output, {
+            "type": "Timeout",
+            "message": f"Execution exceeded {timeout} seconds",
+        }
+    finally:
+        try:
+            os.unlink(wrapper_path)
+        except OSError:
+            pass
+

--- a/backend/app/utils/security.py
+++ b/backend/app/utils/security.py
@@ -1,0 +1,10 @@
+"""Security helpers for sandboxing subprocess execution."""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+
+def build_preexec_fn() -> Optional[Callable[[], None]]:
+    """Return a callable that configures resource limits for subprocesses."""
+    return None
+

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1,0 +1,46 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.app.pipelets.runtime import run_pipelet
+
+
+def test_success_return_value():
+    code = """
+def run(message, context):
+    return {"x": message.get("a", 0) + 1}
+"""
+    result, debug, error = run_pipelet(code, {"a": 1}, {})
+    assert result == {"x": 2}
+    assert debug == ""
+    assert error is None
+
+
+def test_syntax_error():
+    code = """
+def run(message, context)
+    return 42
+"""
+    result, debug, error = run_pipelet(code, {}, {})
+    assert result is None
+    assert error is not None
+    assert error["type"] in {"SyntaxError", "Exception"}
+    assert "SyntaxError" in debug
+
+
+def test_timeout():
+    code = """
+import time
+
+def run(message, context):
+    time.sleep(5)
+"""
+    result, debug, error = run_pipelet(code, {}, {}, timeout=1.0)
+    assert result is None
+    assert error is not None
+    assert error["type"] == "Timeout"
+    assert "Execution exceeded" in error["message"]
+


### PR DESCRIPTION
## Summary
- add a subprocess-based runtime helper to execute pipelet code with timeout handling
- provide a security helper stub for future resource limit configuration
- ensure app factory imports are lazy to avoid optional dependency requirements
- cover the runtime behaviour with unit tests for success, syntax errors, and timeouts

## Testing
- pytest backend/tests/test_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68d1545b3b7883228561cca9870321c0