### PR TITLE
Pipelet API (CRUD + test run + logs)

### DIFF
--- a/backend/app/api/pipelets.py
+++ b/backend/app/api/pipelets.py
@@ -1,0 +1,165 @@
+"""REST API endpoints for managing and testing pipelets."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from typing import Any, Dict
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models.logs import RunLog
+from ..models.pipelet import ALLOWED_EVENTS, Pipelet
+from ..pipelets.runtime import run_pipelet
+
+bp = Blueprint("pipelets", __name__)
+
+
+def _pipelet_to_dict(pipelet: Pipelet) -> Dict[str, Any]:
+    """Serialize a pipelet model to a JSON compatible dictionary."""
+
+    return {
+        "id": pipelet.id,
+        "name": pipelet.name,
+        "event": pipelet.event,
+        "code": pipelet.code,
+        "created_at": pipelet.created_at.isoformat() + "Z",
+        "updated_at": pipelet.updated_at.isoformat() + "Z",
+    }
+
+
+def _validate_pipelet_payload(payload: Dict[str, Any]) -> tuple[Dict[str, Any], list[str]]:
+    """Validate and normalize incoming pipelet payloads."""
+
+    errors: list[str] = []
+    name = (payload.get("name") or "").strip()
+    event = (payload.get("event") or "").strip()
+    code = payload.get("code") or ""
+
+    if not name:
+        errors.append("name is required")
+
+    if not event:
+        errors.append("event is required")
+    elif event not in ALLOWED_EVENTS:
+        errors.append("event is not supported")
+
+    if not isinstance(code, str) or not code.strip():
+        errors.append("code is required")
+    elif "def run(" not in code:
+        errors.append("code must define a run function")
+
+    return {"name": name, "event": event, "code": code}, errors
+
+
+def _ensure_unique_name(name: str, pipelet_id: int | None = None) -> bool:
+    """Check whether the given name is unique across pipelets."""
+
+    query = Pipelet.query.filter(func.lower(Pipelet.name) == name.lower())
+    if pipelet_id is not None:
+        query = query.filter(Pipelet.id != pipelet_id)
+    return not db.session.query(query.exists()).scalar()
+
+
+@bp.post("/pipelets")
+def create_pipelet() -> tuple[object, int]:
+    payload = request.get_json(force=True, silent=True) or {}
+    data, errors = _validate_pipelet_payload(payload)
+    if errors:
+        return jsonify({"errors": errors}), HTTPStatus.BAD_REQUEST
+
+    if not _ensure_unique_name(data["name"]):
+        return jsonify({"error": "pipelet with this name already exists"}), HTTPStatus.CONFLICT
+
+    pipelet = Pipelet(**data)
+    db.session.add(pipelet)
+    db.session.commit()
+
+    return jsonify(_pipelet_to_dict(pipelet)), HTTPStatus.CREATED
+
+
+@bp.get("/pipelets")
+def list_pipelets() -> tuple[object, int]:
+    event_filter = request.args.get("event")
+    query = Pipelet.query
+    if event_filter:
+        query = query.filter_by(event=event_filter)
+    pipelets = query.order_by(Pipelet.created_at.desc()).all()
+    return jsonify([_pipelet_to_dict(pipelet) for pipelet in pipelets]), HTTPStatus.OK
+
+
+@bp.get("/pipelets/<int:pipelet_id>")
+def get_pipelet(pipelet_id: int) -> tuple[object, int]:
+    pipelet = Pipelet.query.get_or_404(pipelet_id)
+    return jsonify(_pipelet_to_dict(pipelet)), HTTPStatus.OK
+
+
+@bp.put("/pipelets/<int:pipelet_id>")
+def update_pipelet(pipelet_id: int) -> tuple[object, int]:
+    pipelet = Pipelet.query.get_or_404(pipelet_id)
+    payload = request.get_json(force=True, silent=True) or {}
+    data, errors = _validate_pipelet_payload(payload)
+    if errors:
+        return jsonify({"errors": errors}), HTTPStatus.BAD_REQUEST
+
+    if not _ensure_unique_name(data["name"], pipelet.id):
+        return jsonify({"error": "pipelet with this name already exists"}), HTTPStatus.CONFLICT
+
+    pipelet.name = data["name"]
+    pipelet.event = data["event"]
+    pipelet.code = data["code"]
+    db.session.commit()
+
+    return jsonify(_pipelet_to_dict(pipelet)), HTTPStatus.OK
+
+
+@bp.delete("/pipelets/<int:pipelet_id>")
+def delete_pipelet(pipelet_id: int) -> tuple[object, int]:
+    pipelet = Pipelet.query.get_or_404(pipelet_id)
+    db.session.delete(pipelet)
+    db.session.commit()
+    return "", HTTPStatus.NO_CONTENT
+
+
+@bp.post("/pipelets/<int:pipelet_id>/test")
+def test_pipelet(pipelet_id: int) -> tuple[object, int]:
+    pipelet = Pipelet.query.get_or_404(pipelet_id)
+    payload = request.get_json(force=True, silent=True) or {}
+
+    message = payload.get("message") or {}
+    context = payload.get("context") or {}
+    timeout = payload.get("timeout")
+
+    if not isinstance(message, dict):
+        return jsonify({"error": "message must be an object"}), HTTPStatus.BAD_REQUEST
+    if not isinstance(context, dict):
+        return jsonify({"error": "context must be an object"}), HTTPStatus.BAD_REQUEST
+    if timeout is not None:
+        try:
+            timeout = float(timeout)
+        except (TypeError, ValueError):
+            return jsonify({"error": "timeout must be a number"}), HTTPStatus.BAD_REQUEST
+    else:
+        timeout = 1.5
+
+    result, debug, error = run_pipelet(pipelet.code, message, context, timeout=timeout)
+
+    log_payload: Dict[str, Any] = {
+        "pipelet": pipelet.name,
+        "event": pipelet.event,
+        "debug": debug,
+        "error": error,
+    }
+    run_log = RunLog(source="pipelet", message=json.dumps(log_payload))
+    db.session.add(run_log)
+    db.session.commit()
+
+    response: Dict[str, Any] = {
+        "result": result,
+        "debug": debug,
+        "error": error,
+    }
+    return jsonify(response), HTTPStatus.OK
+

--- a/backend/app/models/pipelet.py
+++ b/backend/app/models/pipelet.py
@@ -6,6 +6,14 @@ from datetime import datetime
 
 from ..extensions import db
 
+ALLOWED_EVENTS = [
+    "BootNotification",
+    "Heartbeat",
+    "Authorize",
+    "StartTransaction",
+    "StopTransaction",
+]
+
 
 class Pipelet(db.Model):
     """Represents a Pipelet definition."""

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -10,6 +10,8 @@ class TestConfig(Config):
 
     TESTING = True
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    ENABLE_OCPP_SERVER = False
+    ENABLE_SIM_API = False
 
 
 def create_test_app():

--- a/backend/tests/test_pipelet_api.py
+++ b/backend/tests/test_pipelet_api.py
@@ -1,0 +1,157 @@
+"""Tests for the Pipelet CRUD and execution API endpoints."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import pytest
+from sqlalchemy.pool import StaticPool
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import Config, create_app
+from backend.app.extensions import db
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite+pysqlite:///:memory:"
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        "poolclass": StaticPool,
+        "connect_args": {"check_same_thread": False},
+    }
+    ENABLE_OCPP_SERVER = False
+    ENABLE_SIM_API = False
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = create_app(TestConfig)
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+    db.session.remove()
+    ctx.pop()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _create_pipelet(client) -> dict[str, object]:
+    response = client.post(
+        "/api/pipelets",
+        json={
+            "name": "TestPipelet",
+            "event": "Heartbeat",
+            "code": "def run(message, context):\n    return message",
+        },
+    )
+    assert response.status_code == 201
+    return response.get_json()
+
+
+def test_create_pipelet(client):
+    response = client.post(
+        "/api/pipelets",
+        json={
+            "name": "Alpha",
+            "event": "Authorize",
+            "code": "def run(message, context):\n    return 1",
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["name"] == "Alpha"
+    assert data["event"] == "Authorize"
+    assert data["code"].startswith("def run")
+
+
+def test_create_pipelet_duplicate_name(client):
+    payload = {
+        "name": "Duplicate",
+        "event": "BootNotification",
+        "code": "def run(message, context):\n    return None",
+    }
+    assert client.post("/api/pipelets", json=payload).status_code == 201
+
+    response = client.post(
+        "/api/pipelets",
+        json={**payload, "name": payload["name"].lower()},
+    )
+
+    assert response.status_code == 409
+
+
+def test_update_and_get_pipelet(client):
+    created = _create_pipelet(client)
+
+    update_payload = {
+        "name": "UpdatedPipelet",
+        "event": "StartTransaction",
+        "code": "def run(message, context):\n    return {\"value\": 42}",
+    }
+    update_response = client.put(
+        f"/api/pipelets/{created['id']}", json=update_payload
+    )
+    assert update_response.status_code == 200
+    updated = update_response.get_json()
+    assert updated["name"] == update_payload["name"]
+    assert updated["event"] == update_payload["event"]
+
+    detail_response = client.get(f"/api/pipelets/{created['id']}")
+    assert detail_response.status_code == 200
+    detail = detail_response.get_json()
+    assert detail["name"] == update_payload["name"]
+    assert detail["event"] == update_payload["event"]
+    assert detail["code"] == update_payload["code"]
+
+
+def test_pipelet_test_run_success(client):
+    created = _create_pipelet(client)
+
+    response = client.post(
+        f"/api/pipelets/{created['id']}/test",
+        json={"message": {"value": 3}, "context": {"extra": True}},
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["result"] == {"value": 3}
+    assert data["debug"] == ""
+    assert data["error"] is None
+
+    logs_response = client.get("/api/logs", query_string={"source": "pipelet", "limit": 1})
+    assert logs_response.status_code == 200
+    logs = logs_response.get_json()
+    assert logs, "expected a run log entry for the pipelet execution"
+    payload = json.loads(logs[0]["message"])
+    assert payload["pipelet"] == created["name"]
+    assert payload["event"] == created["event"]
+
+
+def test_pipelet_test_run_timeout(client):
+    response = client.post(
+        "/api/pipelets",
+        json={
+            "name": "SlowPipelet",
+            "event": "StopTransaction",
+            "code": "import time\n\ndef run(message, context):\n    time.sleep(2)",
+        },
+    )
+    pipelet = response.get_json()
+
+    test_response = client.post(
+        f"/api/pipelets/{pipelet['id']}/test",
+        json={"message": {}, "timeout": 0.1},
+    )
+    assert test_response.status_code == 200
+    data = test_response.get_json()
+    assert data["result"] is None
+    assert data["error"]["type"] == "Timeout"
+


### PR DESCRIPTION
## Summary
- add a `/api/pipelets` blueprint that implements CRUD operations, validation and a test-execution endpoint that writes run logs
- expose allowed pipelet events on the model and register the pipelet API while making simulator and OCPP server startup optional for tests
- add API test coverage for pipelet workflows and update the health test configuration for the new flags

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d157c24c8c8322938220fd3ac17d08