### PR TITLE
Built-in pipelets + export/import + seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,42 @@ This exposes the backend under [http://localhost:5000](http://localhost:5000) an
 ## Continuous Integration
 
 GitHub Actions runs linting (Ruff) and the pytest suite on every push and pull request to ensure code quality.
+
+## Built-in pipelets
+
+The backend ships with a curated set of built-in pipelet templates that cover common tasks such as routing decisions, conditional
+filtering, structured logging and integrations (HTTP webhook, MQTT stub). Their source can be found under
+`backend/app/pipelets/builtins`. Each template defines a `run` function and is available in the UI palette as soon as it exists in
+the database.
+
+Use the seed script below to populate the database with the latest versions of all built-in definitions.
+
+## Export & import
+
+Complete configurations consisting of pipelets and workflows can be exported as JSON and later restored. The API exposes two
+endpoints:
+
+- `GET /api/export` – returns the current snapshot with lists of pipelets and workflows.
+- `POST /api/import` – accepts the same structure and recreates or updates the stored definitions. Passing `?overwrite=true`
+  updates entries with matching names; without the flag the import fails if duplicates are encountered.
+
+The JSON structure has the shape:
+
+```json
+{
+  "version": 1,
+  "pipelets": [{"name": "…", "event": "…", "code": "…"}],
+  "workflows": [{"name": "…", "event": "…", "graph_json": "…"}]
+}
+```
+
+## Seed example data
+
+Run the seed script to insert the built-in pipelets and an example workflow (`Debug Template -> Start Meter Transformer -> HTTP
+Webhook`) bound to the `StartTransaction` event:
+
+```bash
+python backend/scripts/seed.py
+```
+
+The script is idempotent – it updates existing entries to the shipped defaults.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -19,6 +19,7 @@ def create_app(config_class: type[Config] = Config) -> Flask:
 
     from .api.health import bp as health_bp
     from .api.logs import bp as logs_bp
+    from .api.export import bp as export_bp
     from .api.pipelets import bp as pipelets_bp
     from .api.workflow import bp as workflow_bp
 
@@ -30,6 +31,7 @@ def create_app(config_class: type[Config] = Config) -> Flask:
     app.register_blueprint(logs_bp, url_prefix="/api")
     if sim_bp is not None:
         app.register_blueprint(sim_bp, url_prefix="/api")
+    app.register_blueprint(export_bp, url_prefix="/api")
     app.register_blueprint(pipelets_bp, url_prefix="/api")
     app.register_blueprint(workflow_bp, url_prefix="/api")
 

--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -1,0 +1,187 @@
+"""API endpoints for exporting and importing configuration snapshots."""
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any, Iterable
+
+from flask import Blueprint, jsonify, request
+
+from ..extensions import db
+from ..models.pipelet import Pipelet
+from ..models.workflow import Workflow
+from .pipelets import _validate_pipelet_payload
+from .workflow import _normalize_event, _normalize_graph
+
+bp = Blueprint("export", __name__)
+
+
+def _serialize_pipelets(pipelets: Iterable[Pipelet]) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": pipelet.name,
+            "event": pipelet.event,
+            "code": pipelet.code,
+        }
+        for pipelet in pipelets
+    ]
+
+
+def _serialize_workflows(workflows: Iterable[Workflow]) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": workflow.name,
+            "event": workflow.event,
+            "graph_json": workflow.graph_json,
+        }
+        for workflow in workflows
+    ]
+
+
+@bp.get("/export")
+def export_configuration() -> tuple[object, int]:
+    """Return a snapshot of all pipelets and workflows."""
+
+    pipelets = Pipelet.query.order_by(Pipelet.name.asc()).all()
+    workflows = Workflow.query.order_by(Workflow.name.asc()).all()
+    payload = {
+        "version": 1,
+        "pipelets": _serialize_pipelets(pipelets),
+        "workflows": _serialize_workflows(workflows),
+    }
+    return jsonify(payload), HTTPStatus.OK
+
+
+def _validate_pipelets_for_import(
+    payload: list[Any],
+) -> tuple[list[dict[str, Any]], tuple[list[str], int]]:
+    """Validate and normalise the pipelet section of an import payload."""
+
+    normalised: list[dict[str, Any]] = []
+    for index, item in enumerate(payload, start=1):
+        if not isinstance(item, dict):
+            return normalised, ([f"pipelets[{index}] must be an object"], HTTPStatus.BAD_REQUEST)
+        data, errors = _validate_pipelet_payload(item)
+        if errors:
+            return normalised, (errors, HTTPStatus.BAD_REQUEST)
+        normalised.append(data)
+    return normalised, ([], HTTPStatus.OK)
+
+
+def _is_workflow_event_conflict(event: str | None, workflow_id: int | None = None) -> bool:
+    if event is None:
+        return False
+    query = Workflow.query.filter(Workflow.event == event)
+    if workflow_id is not None:
+        query = query.filter(Workflow.id != workflow_id)
+    return db.session.query(query.exists()).scalar()  # type: ignore[arg-type]
+
+
+def _validate_workflows_for_import(
+    payload: list[Any],
+) -> tuple[list[dict[str, Any]], tuple[list[str], int]]:
+    normalised: list[dict[str, Any]] = []
+    for index, item in enumerate(payload, start=1):
+        if not isinstance(item, dict):
+            return normalised, ([f"workflows[{index}] must be an object"], HTTPStatus.BAD_REQUEST)
+
+        name = (item.get("name") or "").strip()
+        if not name:
+            return normalised, (["name is required"], HTTPStatus.BAD_REQUEST)
+
+        graph_text, graph_errors = _normalize_graph(
+            item.get("graph_json"), allow_default=True
+        )
+        if graph_errors:
+            return normalised, (graph_errors, HTTPStatus.BAD_REQUEST)
+
+        event_value, event_errors = _normalize_event(item.get("event"))
+        if event_errors:
+            return normalised, (event_errors, HTTPStatus.BAD_REQUEST)
+
+        normalised.append(
+            {
+                "name": name,
+                "graph_json": graph_text,
+                "event": event_value,
+            }
+        )
+    return normalised, ([], HTTPStatus.OK)
+
+
+@bp.post("/import")
+def import_configuration() -> tuple[object, int]:
+    """Import pipelets and workflows from a snapshot."""
+
+    payload = request.get_json(force=True, silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"error": "payload must be an object"}), HTTPStatus.BAD_REQUEST
+
+    overwrite_flag = request.args.get("overwrite", "false").lower()
+    overwrite = overwrite_flag in {"1", "true", "yes"}
+
+    pipelet_items = payload.get("pipelets", [])
+    workflow_items = payload.get("workflows", [])
+
+    if not isinstance(pipelet_items, list):
+        return jsonify({"error": "pipelets must be a list"}), HTTPStatus.BAD_REQUEST
+    if not isinstance(workflow_items, list):
+        return jsonify({"error": "workflows must be a list"}), HTTPStatus.BAD_REQUEST
+
+    pipelets, (pipelet_errors, pipelet_status) = _validate_pipelets_for_import(pipelet_items)
+    if pipelet_errors:
+        return jsonify({"errors": pipelet_errors}), pipelet_status
+
+    workflows, (workflow_errors, workflow_status) = _validate_workflows_for_import(
+        workflow_items
+    )
+    if workflow_errors:
+        return jsonify({"errors": workflow_errors}), workflow_status
+
+    created = 0
+    updated = 0
+
+    for data in pipelets:
+        existing = Pipelet.query.filter_by(name=data["name"]).first()
+        if existing is not None:
+            if not overwrite:
+                return (
+                    jsonify({"error": f"pipelet {data['name']} already exists"}),
+                    HTTPStatus.CONFLICT,
+                )
+            existing.event = data["event"]
+            existing.code = data["code"]
+            updated += 1
+        else:
+            pipelet = Pipelet(**data)
+            db.session.add(pipelet)
+            created += 1
+
+    for data in workflows:
+        existing = Workflow.query.filter_by(name=data["name"]).first()
+        if existing is not None:
+            if not overwrite:
+                return (
+                    jsonify({"error": f"workflow {data['name']} already exists"}),
+                    HTTPStatus.CONFLICT,
+                )
+            if _is_workflow_event_conflict(data["event"], existing.id):
+                return (
+                    jsonify({"error": "event ist bereits zugeordnet"}),
+                    HTTPStatus.CONFLICT,
+                )
+            existing.graph_json = data["graph_json"]
+            existing.event = data["event"]
+            updated += 1
+        else:
+            if _is_workflow_event_conflict(data["event"], None):
+                return (
+                    jsonify({"error": "event ist bereits zugeordnet"}),
+                    HTTPStatus.CONFLICT,
+                )
+            workflow = Workflow(**data)
+            db.session.add(workflow)
+            created += 1
+
+    db.session.commit()
+
+    return jsonify({"created": created, "updated": updated}), HTTPStatus.OK

--- a/backend/app/pipelets/__init__.py
+++ b/backend/app/pipelets/__init__.py
@@ -1,1 +1,9 @@
 """Pipelet runtime package."""
+
+from .builtins import find_builtin, get_builtin_pipelets, iter_builtin_pipelets
+
+__all__ = [
+    "find_builtin",
+    "get_builtin_pipelets",
+    "iter_builtin_pipelets",
+]

--- a/backend/app/pipelets/builtins/__init__.py
+++ b/backend/app/pipelets/builtins/__init__.py
@@ -1,0 +1,97 @@
+"""Collection of built-in pipelet templates provided by the platform."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from . import filter as builtin_filter
+from . import http_webhook
+from . import logger
+from . import mqtt_publish
+from . import router
+from . import template
+from . import transformer
+
+
+@dataclass(frozen=True)
+class BuiltinPipelet:
+    """Metadata describing a built-in pipelet template."""
+
+    name: str
+    event: str
+    code: str
+    description: str
+
+
+def _normalize(code: str) -> str:
+    """Normalise code blocks to keep indentation consistent."""
+
+    stripped = code.strip("\n")
+    return f"{stripped}\n"
+
+
+_BUILTINS: List[BuiltinPipelet] = [
+    BuiltinPipelet(
+        name=template.DEFAULT_NAME,
+        event=template.DEFAULT_EVENT,
+        code=_normalize(template.CODE),
+        description=template.DESCRIPTION,
+    ),
+    BuiltinPipelet(
+        name=transformer.DEFAULT_NAME,
+        event=transformer.DEFAULT_EVENT,
+        code=_normalize(transformer.CODE),
+        description=transformer.DESCRIPTION,
+    ),
+    BuiltinPipelet(
+        name=filter.DEFAULT_NAME,
+        event=filter.DEFAULT_EVENT,
+        code=_normalize(filter.CODE),
+        description=filter.DESCRIPTION,
+    ),
+    BuiltinPipelet(
+        name=router.DEFAULT_NAME,
+        event=router.DEFAULT_EVENT,
+        code=_normalize(router.CODE),
+        description=router.DESCRIPTION,
+    ),
+    BuiltinPipelet(
+        name=http_webhook.DEFAULT_NAME,
+        event=http_webhook.DEFAULT_EVENT,
+        code=_normalize(http_webhook.CODE),
+        description=http_webhook.DESCRIPTION,
+    ),
+    BuiltinPipelet(
+        name=mqtt_publish.DEFAULT_NAME,
+        event=mqtt_publish.DEFAULT_EVENT,
+        code=_normalize(mqtt_publish.CODE),
+        description=mqtt_publish.DESCRIPTION,
+    ),
+    BuiltinPipelet(
+        name=logger.DEFAULT_NAME,
+        event=logger.DEFAULT_EVENT,
+        code=_normalize(logger.CODE),
+        description=logger.DESCRIPTION,
+    ),
+]
+
+
+def get_builtin_pipelets() -> list[BuiltinPipelet]:
+    """Return a copy of the available built-in pipelet templates."""
+
+    return list(_BUILTINS)
+
+
+def iter_builtin_pipelets() -> Iterable[BuiltinPipelet]:
+    """Yield the registered built-in pipelets."""
+
+    yield from _BUILTINS
+
+
+def find_builtin(name: str) -> BuiltinPipelet | None:
+    """Return a built-in pipelet by name, if available."""
+
+    for builtin in _BUILTINS:
+        if builtin.name == name:
+            return builtin
+    return None

--- a/backend/app/pipelets/builtins/filter.py
+++ b/backend/app/pipelets/builtins/filter.py
@@ -1,0 +1,14 @@
+"""Conditional filtering pipelet."""
+
+DEFAULT_NAME = "Event Filter"
+DEFAULT_EVENT = "StartTransaction"
+DESCRIPTION = "Lässt nur StartTransaction-Ereignisse durch und dropt andere." 
+
+CODE = '''
+def run(message, context):
+    """Allow only StartTransaction events to pass through."""
+
+    if context.get("event") != "StartTransaction":
+        return None
+    return message
+'''

--- a/backend/app/pipelets/builtins/http_webhook.py
+++ b/backend/app/pipelets/builtins/http_webhook.py
@@ -1,0 +1,26 @@
+"""HTTP webhook integration pipelet."""
+
+DEFAULT_NAME = "HTTP Webhook"
+DEFAULT_EVENT = "StartTransaction"
+DESCRIPTION = "Sendet das Ergebnis per HTTP POST an eine konfigurierbare URL." 
+
+CODE = '''
+from typing import Any
+
+import requests
+
+
+def run(message, context):
+    """Send the payload to a configured webhook URL and continue the flow."""
+
+    url = context.get("webhook_url")
+    if not url:
+        return message
+
+    payload: Any = message if isinstance(message, (dict, list)) else {"data": message}
+    try:
+        requests.post(url, json=payload, timeout=1.0)
+    except Exception as exc:  # pragma: no cover - network issues not deterministic
+        context["webhook_error"] = str(exc)
+    return message
+'''

--- a/backend/app/pipelets/builtins/logger.py
+++ b/backend/app/pipelets/builtins/logger.py
@@ -1,0 +1,22 @@
+"""Structured logging helper."""
+
+DEFAULT_NAME = "Structured Logger"
+DEFAULT_EVENT = "StartTransaction"
+DESCRIPTION = "Schreibt strukturierte Logeinträge in den Kontext (__log)." 
+
+CODE = '''
+from datetime import datetime
+
+def run(message, context):
+    """Append a structured log entry to the context."""
+
+    entries = context.setdefault("__log", [])
+    entries.append(
+        {
+            "level": "info",
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "message": "Pipelet executed",
+        }
+    )
+    return message
+'''

--- a/backend/app/pipelets/builtins/mqtt_publish.py
+++ b/backend/app/pipelets/builtins/mqtt_publish.py
@@ -1,0 +1,18 @@
+"""MQTT publish placeholder pipelet."""
+
+DEFAULT_NAME = "MQTT Publish (Stub)"
+DEFAULT_EVENT = "StartTransaction"
+DESCRIPTION = "Demonstriert die Übergabe an MQTT – derzeit nur Logging im Kontext." 
+
+CODE = '''
+def run(message, context):
+    """Simulate publishing the message to an MQTT topic."""
+
+    topic = context.get("mqtt_topic", "ocpp/pipelet")
+    entries = context.setdefault("__log", [])
+    entries.append({
+        "level": "info",
+        "message": f"MQTT publish to {topic} (stub)",
+    })
+    return message
+'''

--- a/backend/app/pipelets/builtins/router.py
+++ b/backend/app/pipelets/builtins/router.py
@@ -1,0 +1,18 @@
+"""Routing helper to decide downstream targets."""
+
+DEFAULT_NAME = "Routing Decision"
+DEFAULT_EVENT = "StartTransaction"
+DESCRIPTION = "Leitet die Nachricht je nach CP-ID an unterschiedliche Ziele weiter." 
+
+CODE = '''
+def run(message, context):
+    """Decide on a routing target and store it in the context."""
+
+    cp_id = context.get("cp_id", "unknown")
+    if isinstance(cp_id, str) and cp_id.endswith("1"):
+        target = "A"
+    else:
+        target = "B"
+    context.setdefault("route_to", {})["cpms"] = target
+    return message
+'''

--- a/backend/app/pipelets/builtins/template.py
+++ b/backend/app/pipelets/builtins/template.py
@@ -1,0 +1,16 @@
+"""Simple debugging template pipelet."""
+
+DEFAULT_NAME = "Debug Template"
+DEFAULT_EVENT = "StartTransaction"
+DESCRIPTION = "Setzt ein Debug-Feld mit der Chargepoint-ID." 
+
+CODE = '''
+from copy import deepcopy
+
+def run(message, context):
+    """Return an augmented copy of the incoming message for debugging."""
+
+    data = deepcopy(message or {})
+    data["_debug"] = f"cp={context.get('cp_id', 'unknown')}"
+    return data
+'''

--- a/backend/app/pipelets/builtins/transformer.py
+++ b/backend/app/pipelets/builtins/transformer.py
@@ -1,0 +1,16 @@
+"""Message transformation helper."""
+
+DEFAULT_NAME = "Start Meter Transformer"
+DEFAULT_EVENT = "StartTransaction"
+DESCRIPTION = "Benennt meterStart in meter_start um und ergänzt source=ocpp." 
+
+CODE = '''
+def run(message, context):
+    """Rename and enrich fields in the payload."""
+
+    result = dict(message or {})
+    if "meterStart" in result:
+        result["meter_start"] = result.pop("meterStart")
+    result.setdefault("source", "ocpp")
+    return result
+'''

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -1,0 +1,120 @@
+"""Seed the database with built-in pipelets and an example workflow."""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from typing import Iterable
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.app import create_app
+from backend.app.extensions import db
+from backend.app.models.pipelet import Pipelet
+from backend.app.models.workflow import Workflow
+from backend.app.pipelets.builtins import (
+    BuiltinPipelet,
+    find_builtin,
+    iter_builtin_pipelets,
+)
+
+EXAMPLE_WORKFLOW_NAME = "StartTransaction Flow"
+EXAMPLE_EVENT = "StartTransaction"
+
+
+def _ensure_pipelet(builtin: BuiltinPipelet) -> tuple[bool, bool]:
+    """Create or update a pipelet from the built-in definition."""
+
+    created = False
+    updated = False
+
+    pipelet = Pipelet.query.filter_by(name=builtin.name).first()
+    if pipelet is None:
+        pipelet = Pipelet(name=builtin.name, event=builtin.event, code=builtin.code)
+        db.session.add(pipelet)
+        created = True
+    else:
+        if pipelet.event != builtin.event or pipelet.code != builtin.code:
+            pipelet.event = builtin.event
+            pipelet.code = builtin.code
+            updated = True
+    return created, updated
+
+
+def _chain_graph(pipelets: Iterable[BuiltinPipelet]) -> str:
+    """Build a simple linear workflow graph for the provided pipelets."""
+
+    nodes: dict[str, object] = {}
+    items = list(pipelets)
+    for index, builtin in enumerate(items, start=1):
+        outputs = {}
+        if index < len(items):
+            outputs = {"out": {"connections": [{"node": index + 1}]}}
+        nodes[str(index)] = {
+            "id": index,
+            "data": {
+                "code": builtin.code,
+                "pipelet": {"name": builtin.name},
+            },
+            "outputs": outputs,
+        }
+    return json.dumps({"nodes": nodes})
+
+
+def _ensure_example_workflow(pipelets: Iterable[BuiltinPipelet]) -> tuple[bool, bool]:
+    graph_json = _chain_graph(pipelets)
+    workflow = Workflow.query.filter_by(name=EXAMPLE_WORKFLOW_NAME).first()
+    created = False
+    updated = False
+
+    if workflow is None:
+        workflow = Workflow(
+            name=EXAMPLE_WORKFLOW_NAME,
+            event=EXAMPLE_EVENT,
+            graph_json=graph_json,
+        )
+        db.session.add(workflow)
+        created = True
+    else:
+        if workflow.event != EXAMPLE_EVENT or workflow.graph_json != graph_json:
+            workflow.event = EXAMPLE_EVENT
+            workflow.graph_json = graph_json
+            updated = True
+    return created, updated
+
+
+def main() -> None:
+    app = create_app()
+    with app.app_context():
+        created_pipelets = 0
+        updated_pipelets = 0
+        for builtin in iter_builtin_pipelets():
+            created, updated = _ensure_pipelet(builtin)
+            created_pipelets += int(created)
+            updated_pipelets += int(updated)
+
+        template = find_builtin("Debug Template")
+        transformer = find_builtin("Start Meter Transformer")
+        webhook = find_builtin("HTTP Webhook")
+        if template is None or transformer is None or webhook is None:
+            raise RuntimeError("Missing built-in definitions for example workflow")
+
+        created_workflows, updated_workflows = _ensure_example_workflow(
+            [template, transformer, webhook]
+        )
+
+        db.session.commit()
+
+        print(
+            "Seed completed",
+            f"pipelets created={created_pipelets}",
+            f"pipelets updated={updated_pipelets}",
+            f"workflows created={int(created_workflows)}",
+            f"workflows updated={int(updated_workflows)}",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_export_import.py
+++ b/backend/tests/test_export_import.py
@@ -1,0 +1,161 @@
+"""Tests for the export/import configuration API."""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import pytest
+from sqlalchemy.pool import StaticPool
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_app_dependencies():
+    from app import Config, create_app
+    from backend.app.extensions import db
+    from backend.app.models.pipelet import Pipelet
+    from backend.app.models.workflow import Workflow
+
+    return Config, create_app, db, Pipelet, Workflow
+
+
+ConfigBase, create_app, db, Pipelet, Workflow = _load_app_dependencies()
+
+
+class TestConfig(ConfigBase):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite+pysqlite:///:memory:"
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        "poolclass": StaticPool,
+        "connect_args": {"check_same_thread": False},
+    }
+    ENABLE_OCPP_SERVER = False
+    ENABLE_SIM_API = False
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = create_app(TestConfig)
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+    db.session.remove()
+    ctx.pop()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def clean_database():
+    db.session.query(Pipelet).delete()
+    db.session.query(Workflow).delete()
+    db.session.commit()
+    yield
+    db.session.query(Pipelet).delete()
+    db.session.query(Workflow).delete()
+    db.session.commit()
+
+
+def _create_pipelet(name: str, event: str = "StartTransaction") -> Pipelet:
+    pipelet = Pipelet(name=name, event=event, code="def run(message, context):\n    return message")
+    db.session.add(pipelet)
+    db.session.commit()
+    return pipelet
+
+
+def _create_workflow(name: str, event: str = "StartTransaction") -> Workflow:
+    graph = json.dumps({"nodes": {"1": {"id": 1, "data": {"code": "def run(message, context):\n    return message"}}}})
+    workflow = Workflow(name=name, event=event, graph_json=graph)
+    db.session.add(workflow)
+    db.session.commit()
+    return workflow
+
+
+def test_export_roundtrip(client):
+    _create_pipelet("Alpha", "StartTransaction")
+    _create_pipelet("Beta", "Authorize")
+    created_workflow = _create_workflow("WF-1", "StartTransaction")
+
+    response = client.get("/api/export")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["version"] == 1
+    assert len(data["pipelets"]) == 2
+    assert len(data["workflows"]) == 1
+
+    db.session.query(Pipelet).delete()
+    db.session.query(Workflow).delete()
+    db.session.commit()
+
+    import_response = client.post("/api/import", json=data)
+    assert import_response.status_code == 200
+    summary = import_response.get_json()
+    assert summary == {"created": 3, "updated": 0}
+
+    assert Pipelet.query.count() == 2
+    restored = Pipelet.query.filter_by(name="Alpha").first()
+    assert restored is not None
+    assert restored.event == "StartTransaction"
+
+    restored_workflow = Workflow.query.filter_by(name=created_workflow.name).first()
+    assert restored_workflow is not None
+    assert json.loads(restored_workflow.graph_json) == json.loads(created_workflow.graph_json)
+
+
+def test_import_conflict_without_overwrite(client):
+    _create_pipelet("Exists", "Authorize")
+
+    payload = {
+        "version": 1,
+        "pipelets": [
+            {"name": "Exists", "event": "Authorize", "code": "def run(message, context):\n    return message"}
+        ],
+        "workflows": [],
+    }
+
+    response = client.post("/api/import", json=payload)
+    assert response.status_code == 409
+    data = response.get_json()
+    assert "already exists" in data["error"]
+
+
+def test_import_with_overwrite(client):
+    pipelet = _create_pipelet("Overwrite", "Authorize")
+    workflow = _create_workflow("WF-Overwrite", "Authorize")
+
+    payload = {
+        "version": 1,
+        "pipelets": [
+            {
+                "name": "Overwrite",
+                "event": "StartTransaction",
+                "code": "def run(message, context):\n    return {'value': 1}",
+            }
+        ],
+        "workflows": [
+            {
+                "name": "WF-Overwrite",
+                "event": "StartTransaction",
+                "graph_json": json.dumps({"nodes": {}}),
+            }
+        ],
+    }
+
+    response = client.post("/api/import", json=payload, query_string={"overwrite": "true"})
+    assert response.status_code == 200
+    summary = response.get_json()
+    assert summary == {"created": 0, "updated": 2}
+
+    db.session.refresh(pipelet)
+    assert pipelet.event == "StartTransaction"
+    assert "return {'value': 1}" in pipelet.code
+
+    db.session.refresh(workflow)
+    assert workflow.event == "StartTransaction"
+    assert json.loads(workflow.graph_json) == {"nodes": {}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ flask
 flask_sqlalchemy
 pymysql
 flask_cors
+requests
 pytest
 pytest-cov
 ruff


### PR DESCRIPTION
## Summary
- add a catalogue of built-in pipelet templates and expose helper utilities
- implement configuration export/import endpoints and cover them with tests
- add a seed script plus documentation for built-ins and export/import flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d190bdaa448322b5c36278a71c2933