### PR TITLE
UI polish: logs + simulator panel + status

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ docker compose up --build
 This exposes the backend under [http://localhost:5000](http://localhost:5000) and the workflow canvas frontend under
 [http://localhost:5173](http://localhost:5173).
 
+## Simulator dashboard & live logs
+
+The frontend includes a simulator dashboard that bundles charge point controls, connection status indicators and the
+streaming log console:
+
+1. The **Charge Point Simulator** panel lets you choose a custom CP-ID (defaults to `CP_1`), trigger connect/disconnect,
+   send RFID tokens and start/stop transactions or periodic heartbeats. All interactions call the matching REST endpoints
+   under `/api/sim/*`.
+2. The status bars display the connectivity of the central system (WebSocket listener on `:9000`) and the currently
+   selected charge point. They refresh every few seconds and show the timestamp of the latest event.
+3. The live log viewer subscribes to the server-sent events stream, supports source filters, full-text search with
+   highlighting, auto-scroll toggles and a "Nur letzte N" cap. Use the *Clear* button to reset the local view or
+   *Download* to fetch an NDJSON snapshot via `/api/logs/download`.
+
 ## Continuous Integration
 
 GitHub Actions runs linting (Ruff) and the pytest suite on every push and pull request to ensure code quality.

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -1,14 +1,36 @@
-"""API endpoint exposing run log entries."""
+"""API endpoints exposing run log entries."""
 
 from __future__ import annotations
 
+import json
+import time
 from http import HTTPStatus
+from typing import Iterable
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, Response, jsonify, request, stream_with_context
 
 from ..models.logs import RunLog
 
 bp = Blueprint("logs", __name__)
+
+_VALID_SOURCES = {"cp", "cs", "pipelet"}
+
+
+def _serialize_entry(entry: RunLog) -> dict[str, object]:
+    return {
+        "id": entry.id,
+        "source": entry.source,
+        "message": entry.message,
+        "createdAt": entry.created_at.isoformat() + "Z",
+    }
+
+
+def _filter_by_source(query, source: str | None):
+    if source:
+        if source not in _VALID_SOURCES:
+            return None
+        query = query.filter_by(source=source)
+    return query
 
 
 @bp.get("/logs")
@@ -17,21 +39,65 @@ def get_logs() -> tuple[object, int]:
     limit = request.args.get("limit", type=int) or 200
     limit = max(1, min(limit, 200))
 
-    query = RunLog.query
-    if source:
-        query = query.filter_by(source=source)
+    query = _filter_by_source(RunLog.query, source)
+    if query is None:
+        return jsonify({"error": "invalid source"}), HTTPStatus.BAD_REQUEST
 
-    entries = (
-        query.order_by(RunLog.created_at.desc()).limit(limit).all()
-    )
-
-    data = [
-        {
-            "id": entry.id,
-            "source": entry.source,
-            "message": entry.message,
-            "createdAt": entry.created_at.isoformat() + "Z",
-        }
-        for entry in entries
-    ]
+    entries = query.order_by(RunLog.created_at.desc()).limit(limit).all()
+    data = [_serialize_entry(entry) for entry in entries]
     return jsonify(data), HTTPStatus.OK
+
+
+@bp.get("/logs/download")
+def download_logs() -> Response | tuple[object, int]:
+    source = request.args.get("source")
+    limit = request.args.get("limit", type=int) or 200
+    limit = max(1, min(limit, 1000))
+
+    query = _filter_by_source(RunLog.query, source)
+    if query is None:
+        return jsonify({"error": "invalid source"}), HTTPStatus.BAD_REQUEST
+
+    entries = query.order_by(RunLog.created_at.desc()).limit(limit).all()
+    lines = [
+        json.dumps(_serialize_entry(entry))
+        for entry in reversed(entries)
+    ]
+    payload = "\n".join(lines)
+    response = Response(payload, mimetype="application/x-ndjson")
+    response.headers["Content-Disposition"] = "attachment; filename=run-logs.ndjson"
+    return response
+
+
+@bp.get("/logs/stream")
+def stream_logs() -> Response | tuple[object, int]:
+    source = request.args.get("source")
+    query = _filter_by_source(RunLog.query, source)
+    if query is None:
+        return jsonify({"error": "invalid source"}), HTTPStatus.BAD_REQUEST
+
+    latest = query.order_by(RunLog.id.desc()).first()
+    last_id = latest.id if latest is not None else 0
+
+    @stream_with_context
+    def event_stream() -> Iterable[str]:
+        nonlocal last_id
+        yield ": stream-start\n\n"
+        while True:
+            new_query = _filter_by_source(RunLog.query, source)
+            if new_query is None:
+                break
+            new_entries = (
+                new_query.filter(RunLog.id > last_id)
+                .order_by(RunLog.id.asc())
+                .all()
+            )
+            for entry in new_entries:
+                last_id = entry.id
+                payload = json.dumps(_serialize_entry(entry))
+                yield f"data: {payload}\n\n"
+            if not new_entries:
+                yield ": keep-alive\n\n"
+            time.sleep(1)
+
+    return Response(event_stream(), mimetype="text/event-stream")

--- a/backend/app/api/sim.py
+++ b/backend/app/api/sim.py
@@ -6,7 +6,11 @@ from http import HTTPStatus
 
 from flask import Blueprint, current_app, jsonify, request
 
-from ..ocpp.simulator import SimulatorState, get_simulator
+from ..ocpp.simulator import (
+    SimulatorState,
+    SimulatorStatus,
+    get_simulator,
+)
 
 bp = Blueprint("sim", __name__)
 
@@ -22,26 +26,32 @@ def _json_error(message: str, status: HTTPStatus = HTTPStatus.BAD_REQUEST):
     return jsonify({"error": message}), status
 
 
-@bp.post("/sim/connect")
-def connect() -> tuple[object, int]:
-    simulator = get_simulator(current_app)
-    try:
-        state = simulator.connect()
-    except Exception as exc:  # pragma: no cover - defensive branch
-        current_app.logger.exception("Simulator connect failed")
-        return _json_error(str(exc))
-    return jsonify(_serialize_state(state)), HTTPStatus.OK
+def _serialize_timestamp(value: object | None) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        timestamp = value.isoformat()
+        if timestamp.endswith("+00:00"):
+            return timestamp.replace("+00:00", "Z")
+        if not timestamp.endswith("Z"):
+            return f"{timestamp}Z"
+        return timestamp
+    return str(value)
 
 
-@bp.post("/sim/heartbeat/start")
-def start_heartbeat() -> tuple[object, int]:
-    simulator = get_simulator(current_app)
-    try:
-        state = simulator.start_heartbeat()
-    except Exception as exc:  # pragma: no cover - defensive branch
-        current_app.logger.exception("Heartbeat start failed")
-        return _json_error(str(exc))
-    return jsonify(_serialize_state(state)), HTTPStatus.OK
+def _serialize_status(status: SimulatorStatus) -> dict[str, object | None]:
+    return {
+        "connected": status.connected,
+        "last_event_ts": _serialize_timestamp(status.last_event_ts),
+    }
+
+
+def _require_cp_id() -> str:
+    payload = request.get_json(silent=True) or {}
+    cp_id = payload.get("cp_id") or payload.get("cpId")
+    if not isinstance(cp_id, str) or not cp_id.strip():
+        raise ValueError("cp_id is required")
+    return cp_id.strip()
 
 
 def _require_id_tag() -> str:
@@ -52,12 +62,69 @@ def _require_id_tag() -> str:
     return id_tag
 
 
+@bp.post("/sim/connect")
+def connect() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    try:
+        cp_id = _require_cp_id()
+        state = simulator.connect(cp_id)
+    except ValueError as exc:
+        return _json_error(str(exc))
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Simulator connect failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_state(state)), HTTPStatus.OK
+
+
+@bp.post("/sim/disconnect")
+def disconnect() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    try:
+        _require_cp_id()
+        state = simulator.disconnect()
+    except ValueError as exc:
+        return _json_error(str(exc))
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Simulator disconnect failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_state(state)), HTTPStatus.OK
+
+
+@bp.post("/sim/heartbeat/start")
+def start_heartbeat() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    try:
+        cp_id = _require_cp_id()
+        state = simulator.start_heartbeat(cp_id)
+    except ValueError as exc:
+        return _json_error(str(exc))
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Heartbeat start failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_state(state)), HTTPStatus.OK
+
+
+@bp.post("/sim/heartbeat/stop")
+def stop_heartbeat() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    try:
+        cp_id = _require_cp_id()
+        state = simulator.stop_heartbeat(cp_id)
+    except ValueError as exc:
+        return _json_error(str(exc))
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Heartbeat stop failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_state(state)), HTTPStatus.OK
+
+
 @bp.post("/sim/rfid")
 def authorize() -> tuple[object, int]:
     simulator = get_simulator(current_app)
     try:
+        cp_id = _require_cp_id()
         id_tag = _require_id_tag()
-        state = simulator.authorize(id_tag)
+        state = simulator.authorize(cp_id, id_tag)
     except ValueError as exc:
         return _json_error(str(exc))
     except Exception as exc:  # pragma: no cover - defensive branch
@@ -70,8 +137,9 @@ def authorize() -> tuple[object, int]:
 def start_transaction() -> tuple[object, int]:
     simulator = get_simulator(current_app)
     try:
+        cp_id = _require_cp_id()
         id_tag = _require_id_tag()
-        state = simulator.start_transaction(id_tag)
+        state = simulator.start_transaction(cp_id, id_tag)
     except ValueError as exc:
         return _json_error(str(exc))
     except Exception as exc:  # pragma: no cover - defensive branch
@@ -84,8 +152,25 @@ def start_transaction() -> tuple[object, int]:
 def stop_transaction() -> tuple[object, int]:
     simulator = get_simulator(current_app)
     try:
-        state = simulator.stop_transaction()
+        cp_id = _require_cp_id()
+        state = simulator.stop_transaction(cp_id)
+    except ValueError as exc:
+        return _json_error(str(exc))
     except Exception as exc:  # pragma: no cover - defensive branch
         current_app.logger.exception("Stop transaction failed")
         return _json_error(str(exc))
     return jsonify(_serialize_state(state)), HTTPStatus.OK
+
+
+@bp.get("/sim/status")
+def get_status() -> tuple[object, int]:
+    simulator = get_simulator(current_app)
+    cp_id = request.args.get("cp_id", "CP_1").strip()
+    if not cp_id:
+        return _json_error("cp_id is required")
+    try:
+        status = simulator.status(cp_id)
+    except Exception as exc:  # pragma: no cover - defensive branch
+        current_app.logger.exception("Simulator status failed")
+        return _json_error(str(exc))
+    return jsonify(_serialize_status(status)), HTTPStatus.OK

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,9 @@ import {
   type WorkflowSummary,
 } from './api'
 import { PipeletPalette } from './components/PipeletPalette'
+import { LogViewer } from './components/LogViewer'
+import { SimulatorPanel } from './components/SimulatorPanel'
+import { StatusBars } from './components/StatusBars'
 import {
   WorkflowCanvas,
   type WorkflowCanvasHandle,
@@ -29,6 +32,8 @@ function App(): JSX.Element {
   const [isDirty, setIsDirty] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [status, setStatus] = useState<StatusMessage | null>(null)
+  const [cpId, setCpId] = useState('CP_1')
+  const [statusRevision, setStatusRevision] = useState(0)
 
   useEffect(() => {
     listWorkflows()
@@ -51,6 +56,10 @@ function App(): JSX.Element {
   const reportError = (message: string, error: unknown): void => {
     console.error(message, error)
     setStatus({ type: 'error', text: message })
+  }
+
+  const handleSimulatorActionComplete = (): void => {
+    setStatusRevision((previous) => previous + 1)
   }
 
   const handleAddPipelet = async (pipelet: PipeletSummary): Promise<void> => {
@@ -199,6 +208,7 @@ function App(): JSX.Element {
           </div>
         )}
       </header>
+      <StatusBars cpId={cpId} refreshToken={statusRevision} />
       <main className="app-main">
         <aside className="palette-column">
           <h2 className="section-title">Pipelets</h2>
@@ -208,6 +218,18 @@ function App(): JSX.Element {
           <WorkflowCanvas ref={canvasRef} onChange={handleCanvasChange} />
         </section>
       </main>
+      <section className="app-panels">
+        <aside className="app-panels__simulator">
+          <SimulatorPanel
+            cpId={cpId}
+            onCpIdChange={setCpId}
+            onActionComplete={handleSimulatorActionComplete}
+          />
+        </aside>
+        <div className="app-panels__logs">
+          <LogViewer />
+        </div>
+      </section>
     </div>
   )
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -35,6 +35,25 @@ export interface WorkflowUpdatePayload {
 
 export type WorkflowGraph = Record<string, unknown>
 
+export type LogSource = 'cp' | 'cs' | 'pipelet'
+
+export interface LogEntry {
+  id: number
+  source: LogSource
+  message: string
+  createdAt: string
+}
+
+export interface SimulatorState {
+  interval: number
+  transactionId: number | null
+}
+
+export interface SimulatorStatus {
+  connected: boolean
+  lastEventTs: string | null
+}
+
 export async function fetchPipelets(): Promise<PipeletSummary[]> {
   const response = await apiClient.get('/api/pipelets')
   return (response.data as Array<Record<string, unknown>>).map((pipelet) => ({
@@ -87,5 +106,156 @@ function normalizeWorkflow(data: Record<string, unknown>): WorkflowDetail {
     id: Number(data.id),
     name: String(data.name ?? ''),
     graph_json: graph,
+  }
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const responseData = error.response?.data
+    if (responseData && typeof responseData === 'object' && 'error' in responseData) {
+      const message = (responseData as Record<string, unknown>).error
+      if (typeof message === 'string' && message.trim()) {
+        return message
+      }
+    }
+    if (typeof error.message === 'string' && error.message.trim()) {
+      return error.message
+    }
+  } else if (error instanceof Error) {
+    return error.message
+  }
+  return 'Unbekannter Fehler'
+}
+
+export async function fetchLogs(params: { source?: LogSource; limit?: number }): Promise<LogEntry[]> {
+  const { source, limit = 200 } = params
+  const response = await apiClient.get('/api/logs', {
+    params: {
+      source,
+      limit,
+    },
+  })
+  return Array.isArray(response.data)
+    ? (response.data as Array<Record<string, unknown>>).map(normalizeLogEntry)
+    : []
+}
+
+export async function downloadLogs(
+  source: LogSource | 'all',
+  limit = 200,
+): Promise<Blob> {
+  const params: Record<string, string | number | undefined> = {
+    limit,
+  }
+  if (source !== 'all') {
+    params.source = source
+  }
+  const response = await apiClient.get('/api/logs/download', {
+    params,
+    responseType: 'blob',
+  })
+  return response.data as Blob
+}
+
+export async function getSimulatorStatus(cpId: string): Promise<SimulatorStatus> {
+  const response = await apiClient.get('/api/sim/status', {
+    params: {
+      cp_id: cpId,
+    },
+  })
+  return normalizeSimulatorStatus(response.data)
+}
+
+export async function connectSimulator(cpId: string): Promise<SimulatorState> {
+  const response = await apiClient.post('/api/sim/connect', {
+    cp_id: cpId,
+  })
+  return normalizeSimulatorState(response.data)
+}
+
+export async function disconnectSimulator(cpId: string): Promise<SimulatorState> {
+  const response = await apiClient.post('/api/sim/disconnect', {
+    cp_id: cpId,
+  })
+  return normalizeSimulatorState(response.data)
+}
+
+export async function startSimulatorHeartbeat(cpId: string): Promise<SimulatorState> {
+  const response = await apiClient.post('/api/sim/heartbeat/start', {
+    cp_id: cpId,
+  })
+  return normalizeSimulatorState(response.data)
+}
+
+export async function stopSimulatorHeartbeat(cpId: string): Promise<SimulatorState> {
+  const response = await apiClient.post('/api/sim/heartbeat/stop', {
+    cp_id: cpId,
+  })
+  return normalizeSimulatorState(response.data)
+}
+
+export async function sendSimulatorRfid(cpId: string, idTag: string): Promise<SimulatorState> {
+  const response = await apiClient.post('/api/sim/rfid', {
+    cp_id: cpId,
+    idTag,
+  })
+  return normalizeSimulatorState(response.data)
+}
+
+export async function startSimulatorTransaction(
+  cpId: string,
+  idTag: string,
+): Promise<SimulatorState> {
+  const response = await apiClient.post('/api/sim/start', {
+    cp_id: cpId,
+    idTag,
+  })
+  return normalizeSimulatorState(response.data)
+}
+
+export async function stopSimulatorTransaction(cpId: string): Promise<SimulatorState> {
+  const response = await apiClient.post('/api/sim/stop', {
+    cp_id: cpId,
+  })
+  return normalizeSimulatorState(response.data)
+}
+
+export async function getHealthStatus(): Promise<boolean> {
+  try {
+    const response = await apiClient.get('/api/health')
+    return response.status === 200
+  } catch (error) {
+    return false
+  }
+}
+
+function normalizeLogEntry(data: Record<string, unknown>): LogEntry {
+  return {
+    id: Number(data.id ?? 0),
+    source: (data.source as LogSource) ?? 'pipelet',
+    message: String(data.message ?? ''),
+    createdAt: String(data.createdAt ?? ''),
+  }
+}
+
+function normalizeSimulatorState(data: Record<string, unknown>): SimulatorState {
+  const transactionId = data.transactionId
+  return {
+    interval: Number(data.interval ?? 0),
+    transactionId:
+      typeof transactionId === 'number'
+        ? transactionId
+        : transactionId == null
+          ? null
+          : Number(transactionId),
+  }
+}
+
+function normalizeSimulatorStatus(data: Record<string, unknown>): SimulatorStatus {
+  const lastEvent = data.last_event_ts
+  return {
+    connected: Boolean(data.connected),
+    lastEventTs:
+      typeof lastEvent === 'string' && lastEvent.trim() ? lastEvent : null,
   }
 }

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  apiClient,
+  downloadLogs,
+  fetchLogs,
+  getErrorMessage,
+  type LogEntry,
+  type LogSource,
+} from '../api'
+
+interface LogViewerStatus {
+  type: 'success' | 'error'
+  text: string
+}
+
+type StreamState = 'connecting' | 'open' | 'error'
+
+const SOURCE_OPTIONS: Array<{ value: LogSource | 'all'; label: string }> = [
+  { value: 'all', label: 'Alle Quellen' },
+  { value: 'cs', label: 'Central System' },
+  { value: 'cp', label: 'Charge Point' },
+  { value: 'pipelet', label: 'Pipelets' },
+]
+
+export function LogViewer(): JSX.Element {
+  const [entries, setEntries] = useState<LogEntry[]>([])
+  const [source, setSource] = useState<LogSource | 'all'>('all')
+  const [limit, setLimit] = useState(200)
+  const [autoScroll, setAutoScroll] = useState(true)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [status, setStatus] = useState<LogViewerStatus | null>(null)
+  const [streamState, setStreamState] = useState<StreamState>('connecting')
+  const [isDownloading, setIsDownloading] = useState(false)
+  const logContainerRef = useRef<HTMLDivElement | null>(null)
+  const eventSourceRef = useRef<EventSource | null>(null)
+
+  const effectiveLimit = Math.max(20, Math.min(limit, 1000))
+
+  useEffect(() => {
+    let cancelled = false
+    const loadInitial = async (): Promise<void> => {
+      try {
+        const logs = await fetchLogs({
+          source: source === 'all' ? undefined : source,
+          limit: effectiveLimit,
+        })
+        if (cancelled) {
+          return
+        }
+        const ordered = [...logs].reverse()
+        setEntries(ordered.slice(-effectiveLimit))
+      } catch (error) {
+        if (!cancelled) {
+          setStatus({ type: 'error', text: getErrorMessage(error) })
+        }
+      }
+    }
+
+    void loadInitial()
+    return () => {
+      cancelled = true
+    }
+  }, [source, effectiveLimit])
+
+  useEffect(() => {
+    setEntries((prev) => {
+      if (prev.length <= effectiveLimit) {
+        return prev
+      }
+      return prev.slice(prev.length - effectiveLimit)
+    })
+  }, [effectiveLimit])
+
+  useEffect(() => {
+    const base = apiClient.defaults.baseURL?.replace(/\/?$/, '') ?? ''
+    const params = new URLSearchParams()
+    if (source !== 'all') {
+      params.set('source', source)
+    }
+    const url = `${base}/api/logs/stream${params.toString() ? `?${params.toString()}` : ''}`
+
+    setStreamState('connecting')
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close()
+      eventSourceRef.current = null
+    }
+
+    const eventSource = new EventSource(url)
+    eventSourceRef.current = eventSource
+
+    eventSource.onopen = () => {
+      setStreamState('open')
+    }
+
+    eventSource.onerror = () => {
+      setStreamState('error')
+    }
+
+    eventSource.onmessage = (event) => {
+      try {
+        const raw = JSON.parse(event.data) as Record<string, unknown>
+        const payload: LogEntry = {
+          id: Number(raw.id ?? 0),
+          source: ((raw.source as LogSource) ?? 'pipelet') as LogSource,
+          message: String(raw.message ?? ''),
+          createdAt: String(raw.createdAt ?? ''),
+        }
+        setEntries((prev) => {
+          const exists = prev.some((entry) => entry.id === payload.id)
+          const next = exists
+            ? prev.map((entry) => (entry.id === payload.id ? payload : entry))
+            : [...prev, payload]
+          if (next.length > effectiveLimit) {
+            return next.slice(next.length - effectiveLimit)
+          }
+          return next
+        })
+      } catch (error) {
+        setStatus({ type: 'error', text: getErrorMessage(error) })
+      }
+    }
+
+    return () => {
+      eventSource.close()
+      eventSourceRef.current = null
+    }
+  }, [effectiveLimit, source])
+
+  useEffect(() => {
+    if (!status) {
+      return
+    }
+    const timeout = window.setTimeout(() => setStatus(null), 4000)
+    return () => window.clearTimeout(timeout)
+  }, [status])
+
+  useEffect(() => {
+    if (!autoScroll) {
+      return
+    }
+    const container = logContainerRef.current
+    if (container) {
+      container.scrollTop = container.scrollHeight
+    }
+  }, [autoScroll, entries])
+
+  const filteredEntries = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase()
+    if (!query) {
+      return entries
+    }
+    return entries.filter(
+      (entry) =>
+        entry.message.toLowerCase().includes(query) ||
+        entry.source.toLowerCase().includes(query) ||
+        entry.createdAt.toLowerCase().includes(query),
+    )
+  }, [entries, searchTerm])
+
+  const handleLimitChange = (value: number) => {
+    if (Number.isNaN(value)) {
+      return
+    }
+    setLimit(Math.max(20, Math.min(value, 1000)))
+  }
+
+  const handleClear = () => {
+    setEntries([])
+  }
+
+  const handleDownload = async () => {
+    setIsDownloading(true)
+    try {
+      const blob = await downloadLogs(source, effectiveLimit)
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      const suffix = source === 'all' ? 'all' : source
+      link.download = `pipelet-logs-${suffix}-${Date.now()}.ndjson`
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      URL.revokeObjectURL(url)
+      setStatus({ type: 'success', text: 'Log-Download gestartet' })
+    } catch (error) {
+      setStatus({ type: 'error', text: getErrorMessage(error) })
+    } finally {
+      setIsDownloading(false)
+    }
+  }
+
+  const highlight = (text: string) => {
+    const query = searchTerm.trim()
+    if (!query) {
+      return text
+    }
+    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(`(${escaped})`, 'gi')
+    return text.split(regex).map((part, index) => {
+      if (!part) {
+        return null
+      }
+      const isMatch = part.toLowerCase() === query.toLowerCase()
+      return isMatch ? (
+        <mark key={`${part}-${index}`} className="log-viewer__highlight">
+          {part}
+        </mark>
+      ) : (
+        <span key={`${part}-${index}`}>{part}</span>
+      )
+    })
+  }
+
+  return (
+    <section className="log-viewer" aria-label="Live-Logs">
+      <header className="log-viewer__header">
+        <h2>Live-Logs</h2>
+        <span className={`log-viewer__stream log-viewer__stream--${streamState}`}>
+          {streamState === 'open'
+            ? 'Streaming aktiv'
+            : streamState === 'connecting'
+              ? 'Verbindung wird aufgebaut…'
+              : 'Stream getrennt'}
+        </span>
+      </header>
+
+      <div className="log-viewer__controls">
+        <label className="log-viewer__field">
+          <span>Quelle</span>
+          <select value={source} onChange={(event) => setSource(event.target.value as LogSource | 'all')}>
+            {SOURCE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="log-viewer__field">
+          <span>Nur letzte N</span>
+          <input
+            type="number"
+            value={effectiveLimit}
+            min={20}
+            max={1000}
+            onChange={(event) => handleLimitChange(Number(event.target.value))}
+          />
+        </label>
+
+        <label className="log-viewer__field log-viewer__field--search">
+          <span>Suche</span>
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="contains:text"
+            autoComplete="off"
+          />
+        </label>
+
+        <label className="log-viewer__toggle">
+          <input
+            type="checkbox"
+            checked={autoScroll}
+            onChange={(event) => setAutoScroll(event.target.checked)}
+          />
+          Auto-Scroll
+        </label>
+      </div>
+
+      <div className="log-viewer__entries" ref={logContainerRef}>
+        {filteredEntries.length === 0 ? (
+          <p className="log-viewer__empty">Keine Logeinträge gefunden</p>
+        ) : (
+          filteredEntries.map((entry) => (
+            <article key={entry.id} className="log-viewer__entry">
+              <header>
+                <span className={`log-viewer__badge log-viewer__badge--${entry.source}`}>
+                  {entry.source.toUpperCase()}
+                </span>
+                <time dateTime={entry.createdAt}>{entry.createdAt}</time>
+              </header>
+              <p>{highlight(entry.message)}</p>
+            </article>
+          ))
+        )}
+      </div>
+
+      <footer className="log-viewer__actions">
+        <button type="button" onClick={handleClear}>
+          Clear
+        </button>
+        <button type="button" onClick={handleDownload} disabled={isDownloading}>
+          {isDownloading ? 'Download…' : 'Download'}
+        </button>
+      </footer>
+
+      {status && (
+        <div className={`status-message status-message--${status.type}`} role="status">
+          {status.text}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/SimulatorPanel.tsx
+++ b/frontend/src/components/SimulatorPanel.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from 'react'
+
+import {
+  connectSimulator,
+  disconnectSimulator,
+  getErrorMessage,
+  sendSimulatorRfid,
+  startSimulatorHeartbeat,
+  startSimulatorTransaction,
+  stopSimulatorHeartbeat,
+  stopSimulatorTransaction,
+  type SimulatorState,
+} from '../api'
+
+interface SimulatorPanelProps {
+  cpId: string
+  onCpIdChange: (value: string) => void
+  onActionComplete?: () => void
+}
+
+interface PanelStatus {
+  type: 'success' | 'error'
+  text: string
+}
+
+export function SimulatorPanel({
+  cpId,
+  onCpIdChange,
+  onActionComplete,
+}: SimulatorPanelProps): JSX.Element {
+  const [idTag, setIdTag] = useState('TEST_TAG')
+  const [heartbeatActive, setHeartbeatActive] = useState(false)
+  const [isBusy, setIsBusy] = useState(false)
+  const [status, setStatus] = useState<PanelStatus | null>(null)
+  const [lastState, setLastState] = useState<SimulatorState | null>(null)
+
+  useEffect(() => {
+    if (status === null) {
+      return
+    }
+    const timeout = window.setTimeout(() => setStatus(null), 4000)
+    return () => window.clearTimeout(timeout)
+  }, [status])
+
+  const executeAction = async (
+    action: () => Promise<SimulatorState>,
+    successMessage: string,
+    afterSuccess?: (state: SimulatorState) => void,
+  ): Promise<void> => {
+    setIsBusy(true)
+    try {
+      const state = await action()
+      setLastState(state)
+      setStatus({ type: 'success', text: successMessage })
+      afterSuccess?.(state)
+      onActionComplete?.()
+    } catch (error) {
+      setStatus({ type: 'error', text: getErrorMessage(error) })
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  const handleConnect = async (): Promise<void> => {
+    const trimmed = cpId.trim() || 'CP_1'
+    await executeAction(
+      () => connectSimulator(trimmed),
+      `Charge Point ${trimmed} verbunden`,
+      () => {
+        setHeartbeatActive(false)
+      },
+    )
+  }
+
+  const handleDisconnect = async (): Promise<void> => {
+    const trimmed = cpId.trim() || 'CP_1'
+    await executeAction(
+      () => disconnectSimulator(trimmed),
+      `Charge Point ${trimmed} getrennt`,
+      () => {
+        setHeartbeatActive(false)
+      },
+    )
+  }
+
+  const handleSendRfid = async (): Promise<void> => {
+    const trimmed = cpId.trim() || 'CP_1'
+    const tag = idTag.trim() || 'RFID_DEMO'
+    await executeAction(
+      () => sendSimulatorRfid(trimmed, tag),
+      `RFID ${tag} gesendet`,
+    )
+  }
+
+  const handleStartTransaction = async (): Promise<void> => {
+    const trimmed = cpId.trim() || 'CP_1'
+    const tag = idTag.trim() || 'RFID_DEMO'
+    await executeAction(
+      () => startSimulatorTransaction(trimmed, tag),
+      'Ladevorgang gestartet',
+    )
+  }
+
+  const handleStopTransaction = async (): Promise<void> => {
+    const trimmed = cpId.trim() || 'CP_1'
+    await executeAction(
+      () => stopSimulatorTransaction(trimmed),
+      'Ladevorgang gestoppt',
+      () => {
+        setHeartbeatActive(false)
+      },
+    )
+  }
+
+  const handleToggleHeartbeat = async (): Promise<void> => {
+    const trimmed = cpId.trim() || 'CP_1'
+    if (heartbeatActive) {
+      await executeAction(
+        () => stopSimulatorHeartbeat(trimmed),
+        'Heartbeats gestoppt',
+        () => setHeartbeatActive(false),
+      )
+    } else {
+      await executeAction(
+        () => startSimulatorHeartbeat(trimmed),
+        'Heartbeats gestartet',
+        () => setHeartbeatActive(true),
+      )
+    }
+  }
+
+  return (
+    <section className="simulator-panel" aria-label="Simulator-Steuerung">
+      <header className="simulator-panel__header">
+        <h2>Charge Point Simulator</h2>
+        <p>Steuerung für OCPP-Demoaktionen</p>
+      </header>
+
+      <div className="simulator-panel__form">
+        <label className="simulator-panel__field">
+          <span>Charge Point ID</span>
+          <input
+            type="text"
+            value={cpId}
+            onChange={(event) => onCpIdChange(event.target.value)}
+            placeholder="CP_1"
+            autoComplete="off"
+          />
+        </label>
+
+        <label className="simulator-panel__field">
+          <span>RFID / idTag</span>
+          <input
+            type="text"
+            value={idTag}
+            onChange={(event) => setIdTag(event.target.value)}
+            placeholder="RFID_DEMO"
+            autoComplete="off"
+          />
+        </label>
+      </div>
+
+      <div className="simulator-panel__actions">
+        <button type="button" onClick={handleConnect} disabled={isBusy}>
+          Connect
+        </button>
+        <button type="button" onClick={handleDisconnect} disabled={isBusy}>
+          Disconnect
+        </button>
+        <button type="button" onClick={handleSendRfid} disabled={isBusy}>
+          RFID halten
+        </button>
+        <button type="button" onClick={handleStartTransaction} disabled={isBusy}>
+          Start
+        </button>
+        <button type="button" onClick={handleStopTransaction} disabled={isBusy}>
+          Stop
+        </button>
+        <button type="button" onClick={handleToggleHeartbeat} disabled={isBusy}>
+          {heartbeatActive ? 'Heartbeats aus' : 'Heartbeats an'}
+        </button>
+      </div>
+
+      <dl className="simulator-panel__state">
+        <div>
+          <dt>Heartbeat-Intervall</dt>
+          <dd>{lastState ? `${lastState.interval}s` : '—'}</dd>
+        </div>
+        <div>
+          <dt>Transaktion</dt>
+          <dd>
+            {lastState?.transactionId != null && lastState.transactionId >= 0
+              ? `ID ${lastState.transactionId}`
+              : 'keine aktive'}
+          </dd>
+        </div>
+      </dl>
+
+      {status && (
+        <div className={`status-message status-message--${status.type}`} role="status">
+          {status.text}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/StatusBars.tsx
+++ b/frontend/src/components/StatusBars.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { getHealthStatus, getSimulatorStatus, type SimulatorStatus } from '../api'
+
+interface StatusBarsProps {
+  cpId: string
+  refreshToken: number
+}
+
+interface StatusItem {
+  connected: boolean
+  label: string
+  description: string
+  badge: string
+  timestampLabel: string
+  timestamp?: string | null
+}
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) {
+    return '—'
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return date.toLocaleString()
+}
+
+export function StatusBars({ cpId, refreshToken }: StatusBarsProps): JSX.Element {
+  const [csConnected, setCsConnected] = useState(false)
+  const [csCheckedAt, setCsCheckedAt] = useState<string | null>(null)
+  const [cpStatus, setCpStatus] = useState<SimulatorStatus | null>(null)
+  const [cpCheckedAt, setCpCheckedAt] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const fetchStatus = async (): Promise<void> => {
+      const [cs, cp] = await Promise.allSettled([
+        getHealthStatus(),
+        getSimulatorStatus(cpId.trim() || 'CP_1'),
+      ])
+
+      if (!isMounted) {
+        return
+      }
+
+      if (cs.status === 'fulfilled') {
+        setCsConnected(cs.value)
+        setCsCheckedAt(new Date().toISOString())
+      }
+
+      if (cp.status === 'fulfilled') {
+        setCpStatus(cp.value)
+        setCpCheckedAt(new Date().toISOString())
+      } else {
+        setCpStatus(null)
+        setCpCheckedAt(new Date().toISOString())
+      }
+    }
+
+    void fetchStatus()
+    const interval = window.setInterval(fetchStatus, 5000)
+    return () => {
+      isMounted = false
+      window.clearInterval(interval)
+    }
+  }, [cpId, refreshToken])
+
+  const items = useMemo<StatusItem[]>(() => {
+    return [
+      {
+        connected: csConnected,
+        label: 'Central System',
+        description: 'WebSocket Listener :9000',
+        badge: csConnected ? 'Online' : 'Offline',
+        timestampLabel: 'Letzte Prüfung',
+        timestamp: csCheckedAt,
+      },
+      {
+        connected: Boolean(cpStatus?.connected),
+        label: `Charge Point ${cpId || 'CP_1'}`,
+        description: cpStatus?.connected ? 'OCPP verbunden' : 'Keine aktive Verbindung',
+        badge: cpStatus?.connected ? 'Verbunden' : 'Getrennt',
+        timestampLabel: 'Letztes Ereignis',
+        timestamp: cpStatus?.lastEventTs ?? cpCheckedAt,
+      },
+    ]
+  }, [cpCheckedAt, cpId, cpStatus, csCheckedAt, csConnected])
+
+  return (
+    <section className="status-bars" aria-label="Systemstatus">
+      {items.map((item) => (
+        <article key={item.label} className="status-bar">
+          <div className="status-bar__header">
+            <span>{item.label}</span>
+            <span
+              className={`status-indicator ${item.connected ? 'status-indicator--online' : 'status-indicator--offline'}`}
+            >
+              {item.badge}
+            </span>
+          </div>
+          <p className="status-bar__meta">{item.description}</p>
+          <p className="status-bar__timestamp">
+            {item.timestampLabel}: {formatTimestamp(item.timestamp ?? null)}
+          </p>
+        </article>
+      ))}
+    </section>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -92,6 +92,12 @@ button:disabled {
   opacity: 0.5;
 }
 
+input[type='text'],
+input[type='number'],
+select {
+  font-family: inherit;
+}
+
 .app-main {
   flex: 1;
   display: grid;
@@ -191,6 +197,315 @@ button:disabled {
   color: #7f1d1d;
 }
 
+.status-bars {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  padding: 1rem 2rem;
+  background: #e2e8f0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.status-bar {
+  background: #ffffff;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12);
+}
+
+.status-bar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.status-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.status-indicator--online {
+  background: rgba(134, 239, 172, 0.3);
+  color: #166534;
+}
+
+.status-indicator--offline {
+  background: rgba(248, 113, 113, 0.3);
+  color: #7f1d1d;
+}
+
+.status-bar__meta {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.status-bar__timestamp {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.app-panels {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 1px;
+  background: #cbd5f5;
+}
+
+.app-panels__simulator {
+  background: #f8fafc;
+  padding: 1.5rem;
+}
+
+.app-panels__logs {
+  background: #ffffff;
+  padding: 1.5rem;
+  display: flex;
+}
+
+.simulator-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.simulator-panel__header h2 {
+  margin: 0 0 0.35rem;
+}
+
+.simulator-panel__header p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.simulator-panel__form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.simulator-panel__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.simulator-panel__field input {
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: #ffffff;
+  color: #0f172a;
+  font-size: 0.95rem;
+}
+
+.simulator-panel__actions {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.simulator-panel__state {
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.simulator-panel__state dt {
+  margin: 0 0 0.25rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.simulator-panel__state dd {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.log-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+}
+
+.log-viewer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.log-viewer__header h2 {
+  margin: 0;
+}
+
+.log-viewer__stream {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.log-viewer__stream--connecting {
+  color: #f97316;
+}
+
+.log-viewer__stream--open {
+  color: #16a34a;
+}
+
+.log-viewer__stream--error {
+  color: #dc2626;
+}
+
+.log-viewer__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.log-viewer__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #475569;
+  min-width: 140px;
+}
+
+.log-viewer__field select,
+.log-viewer__field input[type='text'],
+.log-viewer__field input[type='number'] {
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: #ffffff;
+  color: #0f172a;
+  font-size: 0.95rem;
+}
+
+.log-viewer__field--search {
+  flex: 1;
+  min-width: 180px;
+}
+
+.log-viewer__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.log-viewer__entries {
+  flex: 1;
+  min-height: 260px;
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  overflow-y: auto;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, monospace;
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.25);
+}
+
+.log-viewer__entry {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  margin-bottom: 0.75rem;
+}
+
+.log-viewer__entry:last-of-type {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.log-viewer__entry header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.8rem;
+}
+
+.log-viewer__entry time {
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.log-viewer__entry p {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-viewer__badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.log-viewer__badge--cs {
+  background: rgba(14, 165, 233, 0.25);
+  color: #7dd3fc;
+}
+
+.log-viewer__badge--cp {
+  background: rgba(124, 58, 237, 0.25);
+  color: #c4b5fd;
+}
+
+.log-viewer__badge--pipelet {
+  background: rgba(34, 197, 94, 0.25);
+  color: #86efac;
+}
+
+.log-viewer__highlight {
+  background: rgba(248, 113, 113, 0.4);
+  color: #ffffff;
+  padding: 0 0.2rem;
+  border-radius: 0.3rem;
+}
+
+.log-viewer__empty {
+  margin: 0;
+  text-align: center;
+  padding: 2rem 0;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.log-viewer__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.log-viewer__actions button {
+  min-width: 120px;
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;
@@ -209,5 +524,18 @@ button:disabled {
 
   .palette-column {
     border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  }
+
+  .status-bars {
+    grid-template-columns: 1fr;
+    padding: 1rem;
+  }
+
+  .app-panels {
+    grid-template-columns: 1fr;
+  }
+
+  .app-panels__logs {
+    padding-top: 0;
   }
 }


### PR DESCRIPTION
## Summary
- extend the simulator backend to handle charge point identifiers, expose status and heartbeat control, and provide NDJSON log downloads plus SSE streaming
- add a simulator control panel, live status indicators, and an enhanced log viewer with filtering, highlighting, download, and auto-scroll controls in the frontend
- document the new simulator dashboard and live log tooling in the README

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1944788f48322a636e83dc9f7ca6c