### PR TITLE
Fix docker compose backend build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   db:
     image: mysql:8
@@ -19,8 +18,8 @@ services:
 
   backend:
     build:
-      context: ./backend
-      dockerfile: ../Dockerfile.backend
+      context: .
+      dockerfile: Dockerfile.backend
     env_file: .env
     environment:
       FLASK_ENV: development


### PR DESCRIPTION
## Summary
- remove deprecated version attribute from docker-compose configuration
- adjust backend build context to include requirements and app files

## Testing
- docker compose build backend *(fails: docker command unavailable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a757a4148322b7e0e495cef4dbde