### PR TITLE
Switch backend API port to 9200

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend /app
-EXPOSE 5000 9000
+EXPOSE 9200 9000
 CMD ["python","wsgi.py"]

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ seed: ## Beispiel-Daten
 
 export: ## Export JSON
 	@if [ -z "$$TOKEN" ]; then echo "Set TOKEN env var with a valid Bearer token"; exit 1; fi
-	curl -H "Authorization: Bearer $$TOKEN" http://localhost:5000/api/export -o export.json
+	curl -H "Authorization: Bearer $$TOKEN" http://localhost:9200/api/export -o export.json
 
 import: ## Import JSON
 	@if [ -z "$$TOKEN" ]; then echo "Set TOKEN env var with a valid Bearer token"; exit 1; fi
-	curl -H "Authorization: Bearer $$TOKEN" -X POST -H "Content-Type: application/json" --data @export.json http://localhost:5000/api/import
+	curl -H "Authorization: Bearer $$TOKEN" -X POST -H "Content-Type: application/json" --data @export.json http://localhost:9200/api/import

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cp .env.example .env
 docker compose up --build
 ```
 
-- API: <http://localhost:5000>
+- API: <http://localhost:9200>
 - Frontend: <http://localhost:5173>
 - OCPP Central System WebSocket: `ws://localhost:9000`
 
@@ -34,7 +34,7 @@ The seed is idempotent and creates the latest built-in pipelets together with th
 Every API request (except `/health`) requires a Bearer token. Create a token in the frontend **TokenPanel** or issue one via:
 
 ```bash
-curl -X POST http://localhost:5000/api/auth/tokens \
+curl -X POST http://localhost:9200/api/auth/tokens \
   -H 'Content-Type: application/json' \
   -d '{"name": "local dev", "role": "admin"}'
 ```

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,5 +1,14 @@
 """WSGI entry point for the Pipelet OCPP backend."""
 
+from __future__ import annotations
+
+import os
+
 from app import create_app
 
 app = create_app()
+
+if __name__ == "__main__":  # pragma: no cover - manual runtime entrypoint
+    port_env = os.getenv("PIPELET_API_PORT") or os.getenv("PORT")
+    port = int(port_env) if port_env else 9200
+    app.run(host="0.0.0.0", port=port)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     depends_on:
       - db
     ports:
-      - "5000:5000"   # Flask API
+      - "9200:9200"   # Flask API
       - "9000:9000"   # OCPP WS (später genutzt)
     command: ["python", "wsgi.py"]
 
@@ -36,7 +36,7 @@ services:
       context: .
       dockerfile: Dockerfile.frontend
     environment:
-      - VITE_API_BASE=http://localhost:5000
+      - VITE_API_BASE=http://localhost:9200
     depends_on:
       - backend
     ports:

--- a/docs/api.postman_collection.json
+++ b/docs/api.postman_collection.json
@@ -413,7 +413,7 @@
                 "type": "text/javascript",
                 "exec": [
                     "if (!pm.variables.get('baseUrl')) {",
-                    "  pm.variables.set('baseUrl', 'http://localhost:5000');",
+                    "  pm.variables.set('baseUrl', 'http://localhost:9200');",
                     "}",
                     "if (!pm.variables.get('token')) {",
                     "  console.warn('Set the `token` variable to a valid Bearer token before calling authenticated routes.');",

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -10,5 +10,5 @@
    ```
 3. Healthcheck aufrufen:
    ```bash
-   curl http://localhost:5000/api/health
+   curl http://localhost:9200/api/health
    ```

--- a/docs/run_on_ my_mac.md
+++ b/docs/run_on_ my_mac.md
@@ -4,7 +4,7 @@ Hier ist eine kurze, pragmatische Test-Checkliste (Docker-Variante zuerst, dann 
 
 Voraussetzungen
 
-Docker Desktop für macOS (Ports 5000, 5173, 9000, 3306 frei).
+Docker Desktop für macOS (Ports 9200, 5173, 9000, 3306 frei).
 
 Repository klonen & .env setzen
 
@@ -20,7 +20,7 @@ docker compose up --build
 
 Danach sollten Backend & Frontend unter diesen URLs erreichbar sein (stehen auch im README):
 
-Backend API: http://localhost:5000
+Backend API: http://localhost:9200
 
 Frontend (Workflow-Canvas + Simulator): http://localhost:5173
  
@@ -39,7 +39,7 @@ Smoke-Tests
 
 Healthcheck:
 
-curl http://localhost:5000/api/health
+curl http://localhost:9200/api/health
 
 
 Erwartet: {"status":"ok"}.
@@ -71,13 +71,13 @@ Export/Import ausprobieren (optional)
 
 Export:
 
-curl http://localhost:5000/api/export -o export.json
+curl http://localhost:9200/api/export -o export.json
 
 
 Import (z.B. in frischer DB):
 
 curl -X POST -H "Content-Type: application/json" \
-     --data @export.json "http://localhost:5000/api/import?overwrite=true"
+     --data @export.json "http://localhost:9200/api/import?overwrite=true"
 
 
 Struktur steht im README.

--- a/docs/test_happy_path.md
+++ b/docs/test_happy_path.md
@@ -3,7 +3,7 @@ Test the complete flow on a mac:
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE="http://localhost:5000"
+BASE="http://localhost:9200"
 
 echo "1) Healthcheck..."
 curl -s $BASE/api/health | jq .


### PR DESCRIPTION
## Summary
- run the Flask backend on port 9200 by default and expose the new port in Docker
- update docker-compose, Makefile commands, and docs to reference the new API port
- allow overriding the runtime port via environment variables in `backend/wsgi.py`

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68d1aa772e748322b572df968245a12f