### PR TITLE
Fix lint issues and modernize imports

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -28,12 +28,12 @@ def create_app(config_class: type[Config] = Config) -> Flask:
 
     limiter.init_app(app)
 
+    from .api.auth import bp as auth_bp
+    from .api.export import bp as export_bp
     from .api.health import bp as health_bp
     from .api.logs import bp as logs_bp
-    from .api.export import bp as export_bp
     from .api.pipelets import bp as pipelets_bp
     from .api.workflow import bp as workflow_bp
-    from .api.auth import bp as auth_bp
 
     sim_bp = None
     if app.config.get("ENABLE_SIM_API", True):

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from http import HTTPStatus
 
 from flask import Blueprint, jsonify, request
@@ -59,6 +59,6 @@ def list_tokens() -> tuple[object, int]:
 def revoke_token(token_id: int) -> tuple[object, int]:
     token = ApiToken.query.get_or_404(token_id)
     if token.revoked_at is None:
-        token.revoked_at = datetime.now(timezone.utc)
+        token.revoked_at = datetime.now(UTC)
         db.session.commit()
     return "", HTTPStatus.NO_CONTENT

--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -1,17 +1,18 @@
 """API endpoints for exporting and importing configuration snapshots."""
 from __future__ import annotations
 
+from collections.abc import Iterable
 from http import HTTPStatus
-from typing import Any, Iterable
+from typing import Any
 
 from flask import Blueprint, jsonify, request
 
 from ..extensions import db
 from ..models.pipelet import Pipelet
 from ..models.workflow import Workflow
+from ..utils.auth import require_token
 from .pipelets import _validate_pipelet_payload
 from .workflow import _normalize_event, _normalize_graph
-from ..utils.auth import require_token
 
 bp = Blueprint("export", __name__)
 

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Iterable
 from http import HTTPStatus
-from typing import Iterable
 
 from flask import Blueprint, Response, jsonify, request, stream_with_context
 
-from ..models.logs import RunLog
 from ..extensions import limiter
+from ..models.logs import RunLog
 from ..utils.auth import require_token
 
 bp = Blueprint("logs", __name__)

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from ..extensions import db
 
@@ -16,7 +16,7 @@ class ApiToken(db.Model):
     name = db.Column(db.String(120), nullable=False)
     token_hash = db.Column(db.String(64), unique=True, nullable=False)
     role = db.Column(db.String(20), nullable=False, default="readonly")
-    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(UTC))
     revoked_at = db.Column(db.DateTime, nullable=True)
 
     def is_active(self) -> bool:

--- a/backend/app/ocpp/server.py
+++ b/backend/app/ocpp/server.py
@@ -17,8 +17,8 @@ from ocpp.v16.enums import Action, AuthorizationStatus, RegistrationStatus
 from websockets.exceptions import ConnectionClosed
 from websockets.server import WebSocketServerProtocol
 
-from .logging import persist_run_log
 from ..workflow.runner import run_workflow_for_event
+from .logging import persist_run_log
 
 OCPP_SUBPROTOCOL = "ocpp1.6"
 

--- a/backend/app/ocpp/simulator.py
+++ b/backend/app/ocpp/simulator.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from collections.abc import Awaitable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Awaitable, TypeVar
+from typing import TypeVar
 
 import websockets
 from flask import Flask

--- a/backend/app/pipelets/builtins/__init__.py
+++ b/backend/app/pipelets/builtins/__init__.py
@@ -1,16 +1,11 @@
 """Collection of built-in pipelet templates provided by the platform."""
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, List
 
 from . import filter as builtin_filter
-from . import http_webhook
-from . import logger
-from . import mqtt_publish
-from . import router
-from . import template
-from . import transformer
+from . import http_webhook, logger, mqtt_publish, router, template, transformer
 
 
 @dataclass(frozen=True)
@@ -30,7 +25,7 @@ def _normalize(code: str) -> str:
     return f"{stripped}\n"
 
 
-_BUILTINS: List[BuiltinPipelet] = [
+_BUILTINS: list[BuiltinPipelet] = [
     BuiltinPipelet(
         name=template.DEFAULT_NAME,
         event=template.DEFAULT_EVENT,
@@ -44,10 +39,10 @@ _BUILTINS: List[BuiltinPipelet] = [
         description=transformer.DESCRIPTION,
     ),
     BuiltinPipelet(
-        name=filter.DEFAULT_NAME,
-        event=filter.DEFAULT_EVENT,
-        code=_normalize(filter.CODE),
-        description=filter.DESCRIPTION,
+        name=builtin_filter.DEFAULT_NAME,
+        event=builtin_filter.DEFAULT_EVENT,
+        code=_normalize(builtin_filter.CODE),
+        description=builtin_filter.DESCRIPTION,
     ),
     BuiltinPipelet(
         name=router.DEFAULT_NAME,

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -6,8 +6,9 @@ import functools
 import hashlib
 import hmac
 import secrets
+from collections.abc import Callable
 from http import HTTPStatus
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from flask import g, jsonify, request
 

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -1,91 +1,90 @@
-"""Seed the database with built-in pipelets and an example workflow."""
+"""Populate the development database with built-in pipelets and workflows."""
+
 from __future__ import annotations
 
 import json
 import pathlib
 import sys
-from typing import Iterable
+from collections.abc import Iterable
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from backend.app import create_app
-from backend.app.extensions import db
-from backend.app.models.pipelet import Pipelet
-from backend.app.models.workflow import Workflow
-from backend.app.pipelets.builtins import (
-    BuiltinPipelet,
-    find_builtin,
-    iter_builtin_pipelets,
-)
-
-EXAMPLE_WORKFLOW_NAME = "StartTransaction Flow"
-EXAMPLE_EVENT = "StartTransaction"
-
-
-def _ensure_pipelet(builtin: BuiltinPipelet) -> tuple[bool, bool]:
-    """Create or update a pipelet from the built-in definition."""
-
-    created = False
-    updated = False
-
-    pipelet = Pipelet.query.filter_by(name=builtin.name).first()
-    if pipelet is None:
-        pipelet = Pipelet(name=builtin.name, event=builtin.event, code=builtin.code)
-        db.session.add(pipelet)
-        created = True
-    else:
-        if pipelet.event != builtin.event or pipelet.code != builtin.code:
-            pipelet.event = builtin.event
-            pipelet.code = builtin.code
-            updated = True
-    return created, updated
-
-
-def _chain_graph(pipelets: Iterable[BuiltinPipelet]) -> str:
-    """Build a simple linear workflow graph for the provided pipelets."""
-
-    nodes: dict[str, object] = {}
-    items = list(pipelets)
-    for index, builtin in enumerate(items, start=1):
-        outputs = {}
-        if index < len(items):
-            outputs = {"out": {"connections": [{"node": index + 1}]}}
-        nodes[str(index)] = {
-            "id": index,
-            "data": {
-                "code": builtin.code,
-                "pipelet": {"name": builtin.name},
-            },
-            "outputs": outputs,
-        }
-    return json.dumps({"nodes": nodes})
-
-
-def _ensure_example_workflow(pipelets: Iterable[BuiltinPipelet]) -> tuple[bool, bool]:
-    graph_json = _chain_graph(pipelets)
-    workflow = Workflow.query.filter_by(name=EXAMPLE_WORKFLOW_NAME).first()
-    created = False
-    updated = False
-
-    if workflow is None:
-        workflow = Workflow(
-            name=EXAMPLE_WORKFLOW_NAME,
-            event=EXAMPLE_EVENT,
-            graph_json=graph_json,
-        )
-        db.session.add(workflow)
-        created = True
-    else:
-        if workflow.event != EXAMPLE_EVENT or workflow.graph_json != graph_json:
-            workflow.event = EXAMPLE_EVENT
-            workflow.graph_json = graph_json
-            updated = True
-    return created, updated
 
 
 def main() -> None:
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+
+    from backend.app import create_app
+    from backend.app.extensions import db
+    from backend.app.models.pipelet import Pipelet
+    from backend.app.models.workflow import Workflow
+    from backend.app.pipelets.builtins import (
+        BuiltinPipelet,
+        find_builtin,
+        iter_builtin_pipelets,
+    )
+
+    EXAMPLE_WORKFLOW_NAME = "StartTransaction Flow"
+    EXAMPLE_EVENT = "StartTransaction"
+
+    def _ensure_pipelet(builtin: BuiltinPipelet) -> tuple[bool, bool]:
+        """Create or update a pipelet from the built-in definition."""
+
+        created = False
+        updated = False
+
+        pipelet = Pipelet.query.filter_by(name=builtin.name).first()
+        if pipelet is None:
+            pipelet = Pipelet(name=builtin.name, event=builtin.event, code=builtin.code)
+            db.session.add(pipelet)
+            created = True
+        else:
+            if pipelet.event != builtin.event or pipelet.code != builtin.code:
+                pipelet.event = builtin.event
+                pipelet.code = builtin.code
+                updated = True
+        return created, updated
+
+    def _chain_graph(pipelets: Iterable[BuiltinPipelet]) -> str:
+        """Build a simple linear workflow graph for the provided pipelets."""
+
+        nodes: dict[str, object] = {}
+        items = list(pipelets)
+        for index, builtin in enumerate(items, start=1):
+            outputs = {}
+            if index < len(items):
+                outputs = {"out": {"connections": [{"node": index + 1}]}}
+            nodes[str(index)] = {
+                "id": index,
+                "data": {
+                    "code": builtin.code,
+                    "pipelet": {"name": builtin.name},
+                },
+                "outputs": outputs,
+            }
+        return json.dumps({"nodes": nodes})
+
+    def _ensure_example_workflow(pipelets: Iterable[BuiltinPipelet]) -> tuple[bool, bool]:
+        graph_json = _chain_graph(pipelets)
+        workflow = Workflow.query.filter_by(name=EXAMPLE_WORKFLOW_NAME).first()
+        created = False
+        updated = False
+
+        if workflow is None:
+            workflow = Workflow(
+                name=EXAMPLE_WORKFLOW_NAME,
+                event=EXAMPLE_EVENT,
+                graph_json=graph_json,
+            )
+            db.session.add(workflow)
+            created = True
+        else:
+            if workflow.event != EXAMPLE_EVENT or workflow.graph_json != graph_json:
+                workflow.event = EXAMPLE_EVENT
+                workflow.graph_json = graph_json
+                updated = True
+        return created, updated
+
     app = create_app()
     with app.app_context():
         created_pipelets = 0
@@ -99,7 +98,8 @@ def main() -> None:
         transformer = find_builtin("Start Meter Transformer")
         webhook = find_builtin("HTTP Webhook")
         if template is None or transformer is None or webhook is None:
-            raise RuntimeError("Missing built-in definitions for example workflow")
+            msg = "Missing built-in definitions for example workflow"
+            raise RuntimeError(msg)
 
         created_workflows, updated_workflows = _ensure_example_workflow(
             [template, transformer, webhook]
@@ -107,7 +107,7 @@ def main() -> None:
 
         db.session.commit()
 
-        print(
+        print(  # noqa: T201
             "Seed completed",
             f"pipelets created={created_pipelets}",
             f"pipelets updated={updated_pipelets}",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import pathlib
 import secrets
 import sys
 from collections.abc import Callable
-from typing import Dict
 
 import pytest
 from sqlalchemy.pool import StaticPool
@@ -56,7 +57,7 @@ def auth_header_factory(app):
 
     created_tokens: list[ApiToken] = []
 
-    def factory(role: str = "admin", name: str | None = None) -> Dict[str, str]:
+    def factory(role: str = "admin", name: str | None = None) -> dict[str, str]:
         token_value = secrets.token_urlsafe(16)
         token = ApiToken(
             name=name or f"Test {role.title()} Token",
@@ -86,10 +87,10 @@ def cleanup_tokens(app):
 
 
 @pytest.fixture()
-def admin_headers(auth_header_factory: Callable[..., Dict[str, str]]):
+def admin_headers(auth_header_factory: Callable[..., dict[str, str]]):
     return auth_header_factory(role="admin")
 
 
 @pytest.fixture()
-def readonly_headers(auth_header_factory: Callable[..., Dict[str, str]]):
+def readonly_headers(auth_header_factory: Callable[..., dict[str, str]]):
     return auth_header_factory(role="readonly")


### PR DESCRIPTION
## Summary
- sort and modernize imports across backend modules to satisfy `ruff`'s linting rules
- replace deprecated timezone and typing usages with modern counterparts
- refactor the seed script to organize imports while keeping helper logic intact
- update test fixtures to use built-in collection types in annotations

## Testing
- `ruff check .`
- `pytest` *(fails: missing optional dependency `flask_limiter` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1adf9c670832298700a1daf3c3cfd