### PR TITLE
Update heading in code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-## Our pledge
+## Our goal
 
 We as members, contributors, and leaders pledge to make participation in the Pipelet OCPP SDK community a harassment-free
 experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender


### PR DESCRIPTION
## Summary
- rename the "Our pledge" heading to "Our goal" in the code of conduct document

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1b06f39608322944631e4088ca5bb