### PR TITLE
Fix MySQL healthcheck credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     command: ["--default-authentication-plugin=mysql_native_password"]
     ports: ["3306:3306"]
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ppassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary
- update the MySQL healthcheck credentials in docker-compose to use the root password defined in the environment

## Testing
- ❌ `docker compose down` *(unavailable: docker not installed in container)*


------
https://chatgpt.com/codex/tasks/task_e_68d1b48b2194832286dd376d368e3578