### PR TITLE
Remove deprecated MySQL auth plugin override

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       MYSQL_USER: app
       MYSQL_PASSWORD: app
       MYSQL_ROOT_PASSWORD: root
-    command: ["--default-authentication-plugin=mysql_native_password"]
     ports: ["3306:3306"]
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ppassword"]


### PR DESCRIPTION
## Summary
- drop the legacy default authentication plugin override from the db service
- allow the mysql:8 image to boot using its default configuration

## Testing
- docker compose up db --build --detach *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b4ba01b483228e52eb934a643f9e