### PR TITLE
Use package-relative import for security utils

### DIFF
--- a/backend/app/pipelets/runtime.py
+++ b/backend/app/pipelets/runtime.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 from typing import Any
 
-from backend.app.utils import security
+from ..utils import security
 
 _PIPELET_WRAPPER_TEMPLATE = """import json, sys\n""" \
     "inp = json.loads(sys.stdin.read() or \"{}\")\n" \


### PR DESCRIPTION
## Summary
- update backend pipelet runtime module to import security helpers using a package-relative path

## Testing
- ⚠️ `docker compose build backend` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b5dcbd888322b0201bd6adfaf022