### PR TITLE
Pin MySQL image to 8.0 for docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mysql:8
+    image: mysql:8.0
     environment:
       MYSQL_DATABASE: pipelet_sandbox
       MYSQL_USER: app


### PR DESCRIPTION
## Summary
- pin the compose stack database image to mysql:8.0 to avoid startup failures during volume reuse

## Testing
- not run (docker is not available in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1b7d9d214832295132ea9066013b8