### PR TITLE
Add retry when initializing database on startup

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,3 +14,5 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS: bool = False
     JSONIFY_PRETTYPRINT_REGULAR: bool = False
     CORS_ALLOWED_ORIGINS: str = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:5173")
+    DB_INIT_MAX_RETRIES: int = int(os.getenv("DB_INIT_MAX_RETRIES", "30"))
+    DB_INIT_RETRY_DELAY: float = float(os.getenv("DB_INIT_RETRY_DELAY", "2"))


### PR DESCRIPTION
## Summary
- add retry logic around database initialization so the backend waits for MySQL when starting
- expose configuration options for retry attempts and delay via environment variables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2584a1114832289384f085585d3fe