### PR TITLE
Pin MySQL image version to 8.0.46

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   db:
-    image: mysql:8.0
+    image: mysql:8.0.46
     hostname: db
     environment:
       MYSQL_DATABASE: pipelet_sandbox


### PR DESCRIPTION
## Summary
- pin the docker-compose MySQL image to version 8.0.46 to align with existing data files and prevent downgrade errors during startup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d26660b51c8322bc4d446bc73c8893