### PR TITLE
Fix MySQL image tag in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.9"
-
 services:
   db:
-    image: mysql:8.0.46
+    image: mysql:8.0
     hostname: db
     environment:
       MYSQL_DATABASE: pipelet_sandbox


### PR DESCRIPTION
## Summary
- remove deprecated top-level version field from docker-compose.yml
- switch database service image to the maintained mysql:8.0 tag so Docker can pull it successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d26acb325083228ffb3badd300fc18