### PR TITLE
Update MySQL image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   db:
-    image: mysql:8.0.46
+    image: mysql:8.0.37
     hostname: db
     environment:
       MYSQL_DATABASE: pipelet_sandbox


### PR DESCRIPTION
## Summary
- switch the database service image to mysql:8.0.37 in docker-compose

## Testing
- docker manifest inspect mysql:8.0.37 *(fails: docker not available in environment)*
- docker compose pull db *(fails: docker not available in environment)*
- docker compose up *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2862a8b348322b5b6e33ba5daa87b