### PR TITLE
Add cryptography dependency for MySQL sha auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flask
 flask_sqlalchemy
 pymysql
+cryptography
 flask_cors
 flask-limiter
 requests


### PR DESCRIPTION
## Summary
- add the cryptography package to the backend requirements so PyMySQL can perform sha256-based authentication

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2888ffc1c832299c867206595eff0