### PR TITLE
Allow 127.0.0.1 frontend origin for CORS by default

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,6 +13,9 @@ class Config:
     )
     SQLALCHEMY_TRACK_MODIFICATIONS: bool = False
     JSONIFY_PRETTYPRINT_REGULAR: bool = False
-    CORS_ALLOWED_ORIGINS: str = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:5173")
+    CORS_ALLOWED_ORIGINS: str = os.getenv(
+        "CORS_ALLOWED_ORIGINS",
+        "http://localhost:5173,http://127.0.0.1:5173",
+    )
     DB_INIT_MAX_RETRIES: int = int(os.getenv("DB_INIT_MAX_RETRIES", "30"))
     DB_INIT_RETRY_DELAY: float = float(os.getenv("DB_INIT_RETRY_DELAY", "2"))


### PR DESCRIPTION
## Summary
- include 127.0.0.1 in the default list of allowed CORS origins for the backend API

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d28ab531a48322a3785bbfc71960dd