### PR TITLE
Improve error handling for unauthorized API responses

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { isAxiosError } from 'axios'
 import { type ChangeEvent, useEffect, useMemo, useRef, useState } from 'react'
 import {
   createWorkflow,
@@ -8,6 +9,7 @@ import {
   type WorkflowDetail,
   type WorkflowGraph,
   type WorkflowSummary,
+  getErrorMessage,
 } from './api'
 import { PipeletPalette } from './components/PipeletPalette'
 import { LogViewer } from './components/LogViewer'
@@ -56,7 +58,21 @@ function App(): JSX.Element {
 
   const reportError = (message: string, error: unknown): void => {
     console.error(message, error)
-    setStatus({ type: 'error', text: message })
+
+    let detail: string | null = null
+    if (isAxiosError(error) && error.response?.status === 401) {
+      detail = 'Zugriff verweigert. Bitte gültiges API-Token im Bereich „API Tokens“ speichern.'
+    } else {
+      const extracted = getErrorMessage(error)
+      if (extracted && extracted !== 'Unbekannter Fehler') {
+        detail = extracted
+      }
+    }
+
+    setStatus({
+      type: 'error',
+      text: detail ? `${message}: ${detail}` : message,
+    })
   }
 
   const handleSimulatorActionComplete = (): void => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -303,7 +303,7 @@ export async function getHealthStatus(): Promise<boolean> {
   try {
     const response = await apiClient.get('/api/health')
     return response.status === 200
-  } catch (error) {
+  } catch {
     return false
   }
 }

--- a/frontend/src/types/rete-react-render-plugin.d.ts
+++ b/frontend/src/types/rete-react-render-plugin.d.ts
@@ -3,16 +3,16 @@ declare module 'rete-react-render-plugin' {
   import type { Plugin } from 'rete'
 
   export interface ReactRenderPluginOptions {
-    component?: ComponentType<any>
+    component?: ComponentType<Record<string, unknown>>
     createRoot?: (container: HTMLElement) => {
       render: (element: ReactElement) => void
       unmount: () => void
     }
   }
 
-  export const Node: ComponentType<any>
-  export const Socket: ComponentType<any>
-  export const Control: ComponentType<any>
+  export const Node: ComponentType<Record<string, unknown>>
+  export const Socket: ComponentType<Record<string, unknown>>
+  export const Control: ComponentType<Record<string, unknown>>
 
   const ReactRenderPlugin: Plugin & {
     name: string


### PR DESCRIPTION
## Summary
- surface API error details when workflow actions fail, with a clear hint for missing tokens
- relax rete React render plugin typings to avoid eslint any usage
- tidy health status helper to satisfy linting rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d28c2ccd6883229d84d6928585e9a3