### PR TITLE
Add API protection toggle and persistence

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -53,7 +53,7 @@ def create_app(config_class: type[Config] = Config) -> Flask:
 
     with app.app_context():
         # Import models to ensure they are registered with SQLAlchemy before creating tables.
-        from .models import auth, logs, pipelet, workflow  # noqa: F401
+        from .models import auth, logs, pipelet, settings, workflow  # noqa: F401
 
         _initialize_database(app)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,7 @@
 from .auth import ApiToken
 from .logs import RunLog
 from .pipelet import Pipelet
+from .settings import AppSetting
 from .workflow import Workflow
 
-__all__ = ["ApiToken", "Pipelet", "Workflow", "RunLog"]
+__all__ = ["ApiToken", "Pipelet", "Workflow", "RunLog", "AppSetting"]

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -1,0 +1,17 @@
+"""Application-wide settings stored in the database."""
+
+from __future__ import annotations
+
+from ..extensions import db
+
+
+class AppSetting(db.Model):
+    """Key/value store for simple application settings."""
+
+    __tablename__ = "app_settings"
+
+    key = db.Column(db.String(64), primary_key=True)
+    value = db.Column(db.String(255), nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<AppSetting {self.key}={self.value}>"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -79,10 +79,12 @@ def auth_header_factory(app):
 @pytest.fixture(autouse=True)
 def cleanup_tokens(app):
     from backend.app.models.auth import ApiToken
+    from backend.app.models.settings import AppSetting
 
     yield
 
     db.session.query(ApiToken).delete()
+    db.session.query(AppSetting).delete()
     db.session.commit()
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import pytest
 
 
+def _set_protection(client, enabled: bool) -> None:
+    response = client.post("/api/auth/protection", json={"enabled": enabled})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, dict)
+    assert data.get("enabled") is enabled
+
+
 @pytest.mark.usefixtures("cleanup_tokens")
 def test_token_issuance_and_listing(client, admin_headers):
     response = client.post(
@@ -26,59 +34,86 @@ def test_token_issuance_and_listing(client, admin_headers):
     assert stored["revoked_at"] is None
 
 
+def test_api_protection_toggle(client):
+    status_response = client.get("/api/auth/protection")
+    assert status_response.status_code == 200
+    assert status_response.get_json()["enabled"] is False
+
+    open_access = client.get("/api/pipelets")
+    assert open_access.status_code == 200
+
+    _set_protection(client, True)
+    try:
+        protected_access = client.get("/api/pipelets")
+        assert protected_access.status_code == 401
+    finally:
+        _set_protection(client, False)
+
+    restored_access = client.get("/api/pipelets")
+    assert restored_access.status_code == 200
+
+
 def test_access_control_for_roles(client, auth_header_factory):
-    # No token is rejected
-    assert client.get("/api/pipelets").status_code == 401
-    assert client.get("/api/logs/stream").status_code == 401
+    _set_protection(client, True)
+    try:
+        # No token is rejected
+        assert client.get("/api/pipelets").status_code == 401
+        assert client.get("/api/logs/stream").status_code == 401
 
-    readonly_headers = auth_header_factory(role="readonly")
-    list_response = client.get("/api/pipelets", headers=readonly_headers)
-    assert list_response.status_code == 200
+        readonly_headers = auth_header_factory(role="readonly")
+        list_response = client.get("/api/pipelets", headers=readonly_headers)
+        assert list_response.status_code == 200
 
-    create_response = client.post(
-        "/api/pipelets",
-        json={
-            "name": "Limited",
-            "event": "Authorize",
-            "code": "def run(message, context):\n    return message",
-        },
-        headers=readonly_headers,
-    )
-    assert create_response.status_code == 403
+        create_response = client.post(
+            "/api/pipelets",
+            json={
+                "name": "Limited",
+                "event": "Authorize",
+                "code": "def run(message, context):\n    return message",
+            },
+            headers=readonly_headers,
+        )
+        assert create_response.status_code == 403
 
-    admin_headers = auth_header_factory(role="admin")
-    admin_create = client.post(
-        "/api/pipelets",
-        json={
-            "name": "AdminPipelet",
-            "event": "Heartbeat",
-            "code": "def run(message, context):\n    return message",
-        },
-        headers=admin_headers,
-    )
-    assert admin_create.status_code == 201
+        admin_headers = auth_header_factory(role="admin")
+        admin_create = client.post(
+            "/api/pipelets",
+            json={
+                "name": "AdminPipelet",
+                "event": "Heartbeat",
+                "code": "def run(message, context):\n    return message",
+            },
+            headers=admin_headers,
+        )
+        assert admin_create.status_code == 201
+    finally:
+        _set_protection(client, False)
 
 
 def test_revoked_token_is_rejected(client, admin_headers):
-    issued = client.post(
-        "/api/auth/tokens",
-        json={"name": "Temp", "role": "readonly"},
-        headers=admin_headers,
-    )
-    token_data = issued.get_json()
-    token_value = token_data["token"]
-    readonly_headers = {"Authorization": f"Bearer {token_value}"}
+    _set_protection(client, True)
+    try:
+        issued = client.post(
+            "/api/auth/tokens",
+            json={"name": "Temp", "role": "readonly"},
+            headers=admin_headers,
+        )
+        token_data = issued.get_json()
+        token_value = token_data["token"]
+        readonly_headers = {"Authorization": f"Bearer {token_value}"}
 
-    initial_access = client.get("/api/pipelets", headers=readonly_headers)
-    assert initial_access.status_code == 200
+        initial_access = client.get("/api/pipelets", headers=readonly_headers)
+        assert initial_access.status_code == 200
 
-    revoke = client.delete(
-        f"/api/auth/tokens/{token_data['id']}", headers=admin_headers
-    )
-    assert revoke.status_code == 204
+        revoke = client.delete(
+            f"/api/auth/tokens/{token_data['id']}", headers=admin_headers
+        )
+        assert revoke.status_code == 204
 
-    revoked_access = client.get("/api/pipelets", headers=readonly_headers)
-    assert revoked_access.status_code == 401
+        revoked_access = client.get("/api/pipelets", headers=readonly_headers)
+        assert revoked_access.status_code == 401
+    finally:
+        _set_protection(client, False)
 
 
 def test_rate_limit_for_pipelet_test_endpoint(client, admin_headers):

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -522,6 +522,84 @@ select {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.token-panel__title {
+  margin: 0;
+}
+
+.token-panel__protection {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.token-panel__protection-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.token-panel__protection-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.token-panel__protection-state {
+  font-weight: 600;
+  color: #ef4444;
+}
+
+.token-panel__protection-state--on {
+  color: #16a34a;
+}
+
+.token-panel__toggle {
+  position: relative;
+  width: 2.6rem;
+  height: 1.4rem;
+  border-radius: 999px;
+  border: none;
+  background: #cbd5f5;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.token-panel__toggle:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.token-panel__toggle--on {
+  background: #22c55e;
+}
+
+.token-panel__toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.token-panel__toggle-thumb {
+  position: absolute;
+  top: 0.2rem;
+  left: 0.2rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.3);
+  transition: transform 0.2s ease;
+}
+
+.token-panel__toggle--on .token-panel__toggle-thumb {
+  transform: translateX(1.2rem);
 }
 
 .token-panel__status {


### PR DESCRIPTION
## Summary
- add a persistent application setting and endpoints to control API token protection
- expose a toggle in the token management panel that manages the protection state without requiring a token
- extend automated tests to cover the new protection workflow and clean up state between cases

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d28e43635083229c386a5b325abb8b