### PR TITLE
Fix workflow canvas rendering by enabling Rete area plugin

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "rete": "^1.5.2",
+        "rete-area-plugin": "^0.2.1",
         "rete-connection-plugin": "^0.9.0",
         "rete-react-render-plugin": "^0.3.1"
       },
@@ -3243,6 +3244,12 @@
       "integrity": "sha512-eUoBubPkhPAJ1dDmVER5uVD1gDM1xEvAD6aMq/E0hgjFyUiIi+twvJjaB2Xc1ZX4DV7QJ9XpB5taiWgurZGwNg==",
       "hasInstallScript": true,
       "license": "MIT"
+    },
+    "node_modules/rete-area-plugin": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rete-area-plugin/-/rete-area-plugin-0.2.1.tgz",
+      "integrity": "sha512-MOeQRmSC/gjkZIMo0fNuomzunRplALqd86V+jSzuhBYchCw0wshv2/iXu4xRxVZkw9r1HpZxlz9gLkbatCbXMw==",
+      "license": "ISC"
     },
     "node_modules/rete-connection-plugin": {
       "version": "0.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rete": "^1.5.2",
+    "rete-area-plugin": "^0.2.1",
     "rete-connection-plugin": "^0.9.0",
     "rete-react-render-plugin": "^0.3.1"
   },

--- a/frontend/src/components/WorkflowCanvas.tsx
+++ b/frontend/src/components/WorkflowCanvas.tsx
@@ -1,8 +1,10 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import { createRoot } from 'react-dom/client'
 import Rete, { Control, Input, Node as ReteNode, NodeEditor, Output, Socket } from 'rete'
+import AreaPlugin from 'rete-area-plugin'
 import ConnectionPlugin from 'rete-connection-plugin'
 import ReactRenderPlugin from 'rete-react-render-plugin'
+import type { Plugin } from 'rete/types/core/plugin'
 import type { PipeletSummary, WorkflowGraph } from '../api'
 
 type EditorJSON = ReturnType<NodeEditor['toJSON']>
@@ -74,6 +76,11 @@ export const WorkflowCanvas = forwardRef<WorkflowCanvasHandle, WorkflowCanvasPro
 
       const editor = new NodeEditor('pipelet-workflow@0.1.0', containerRef.current)
       editor.use(ConnectionPlugin)
+      editor.use(
+        // rete-area-plugin does not ship TypeScript definitions.
+        AreaPlugin as unknown as Plugin,
+        { background: true } as unknown as void,
+      )
       editor.use(ReactRenderPlugin, { createRoot })
 
       const pipeletComponent = new PipeletComponent()
@@ -101,6 +108,7 @@ export const WorkflowCanvas = forwardRef<WorkflowCanvasHandle, WorkflowCanvasPro
       componentRef.current = pipeletComponent
 
       editor.view.resize()
+      AreaPlugin.zoomAt(editor)
       editor.trigger('process')
 
       return () => {
@@ -148,6 +156,7 @@ export const WorkflowCanvas = forwardRef<WorkflowCanvasHandle, WorkflowCanvasPro
             suppressEventsRef.current = false
           }
           editor.view.resize()
+          AreaPlugin.zoomAt(editor)
           editor.trigger('process')
           onChange?.(editor.toJSON() as unknown as WorkflowGraph, 'load')
         },
@@ -160,6 +169,7 @@ export const WorkflowCanvas = forwardRef<WorkflowCanvasHandle, WorkflowCanvasPro
           editor.clear()
           suppressEventsRef.current = false
           editor.trigger('process')
+          AreaPlugin.zoomAt(editor)
           onChange?.({}, 'load')
         },
       }),

--- a/frontend/src/types/rete-area-plugin.d.ts
+++ b/frontend/src/types/rete-area-plugin.d.ts
@@ -1,0 +1,24 @@
+declare module 'rete-area-plugin' {
+  import type { NodeEditor, Node } from 'rete'
+  import type { Plugin } from 'rete/types/core/plugin'
+
+  interface ZoomOptions {
+    (editor: NodeEditor, nodes?: Node[]): void
+  }
+
+  interface AreaPluginOptions {
+    background?: boolean | HTMLElement
+    snap?: boolean | { size?: number }
+    scaleExtent?: boolean | { min: number; max: number }
+    translateExtent?: boolean | { width: number; height: number }
+  }
+
+  interface AreaPluginModule extends Plugin {
+    install(editor: NodeEditor, options?: AreaPluginOptions): void
+    zoomAt: ZoomOptions
+  }
+
+  const plugin: AreaPluginModule
+
+  export default plugin
+}


### PR DESCRIPTION
## Summary
- add the Rete area plugin dependency and custom type declarations so the editor view can render
- update the workflow canvas setup to install the area plugin with a grid background and re-center after loads/resets

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d295773fcc8322bb7596fcd2a94e1d