### PR TITLE
Fix seed import endpoint path

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -356,7 +356,7 @@ export async function importConfiguration(
   options?: { overwrite?: boolean },
 ): Promise<ImportResponse> {
   const overwrite = Boolean(options?.overwrite)
-  const response = await apiClient.post('/api/export/import', payload, {
+  const response = await apiClient.post('/api/import', payload, {
     params: {
       overwrite: overwrite ? 'true' : 'false',
     },


### PR DESCRIPTION
## Summary
- point the seed import API call to the correct /api/import endpoint

## Testing
- not run (npm not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2e8d0e70c83229d2d33254098d656