### PR TITLE
Fix seed workflow import and adjust error styling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -193,8 +193,8 @@ select {
 }
 
 .status-message--error {
-  background: rgba(248, 113, 113, 0.2);
-  color: #7f1d1d;
+  background: rgba(248, 113, 113, 0.85);
+  color: #ffffff;
 }
 
 .status-bars {

--- a/frontend/src/seed.ts
+++ b/frontend/src/seed.ts
@@ -144,6 +144,9 @@ const EXAMPLE_PIPELET_NAMES = [
   'HTTP Webhook',
 ]
 
+// Must match the editor identifier used in WorkflowCanvas
+const WORKFLOW_EDITOR_ID = 'pipelet-workflow@0.1.0'
+
 function buildExampleWorkflowGraph(pipelets: SeedPipelet[]): string {
   const nodes: Record<string, unknown> = {}
   pipelets.forEach((pipelet, index) => {
@@ -168,7 +171,10 @@ function buildExampleWorkflowGraph(pipelets: SeedPipelet[]): string {
           },
     }
   })
-  return JSON.stringify({ nodes })
+  return JSON.stringify({
+    id: WORKFLOW_EDITOR_ID,
+    nodes,
+  })
 }
 
 export function createSeedPayload(): SeedPayload {


### PR DESCRIPTION
## Summary
- include the editor identifier in the seed workflow graph so it can be loaded without runtime errors
- improve the contrast of error status messages by using a white font on the red background

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2eaca28d883228711dd649d5d4467