### PR TITLE
Improve workflow canvas visibility and status styling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -169,14 +169,119 @@ select {
   height: 100%;
   position: absolute;
   inset: 0;
+  overflow: hidden;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.workflow-canvas .rete,
+.workflow-canvas .rete > * {
+  width: 100%;
+  height: 100%;
+}
+
+.workflow-canvas .rete-background.default {
+  background-color: #0f172a;
+  background-image: linear-gradient(
+      to right,
+      rgba(148, 163, 184, 0.18) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(148, 163, 184, 0.18) 1px,
+      transparent 1px
+    );
+}
+
+.workflow-canvas .node {
+  min-width: 220px;
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.55);
+  padding: 0.85rem 1rem 1rem;
+  color: #f8fafc;
+  backdrop-filter: blur(2px);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.workflow-canvas .node.selected {
+  border-color: rgba(56, 189, 248, 0.85);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.35),
+    0 22px 55px rgba(15, 23, 42, 0.7);
+}
+
+.workflow-canvas .title {
+  margin: 0 0 0.6rem;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.workflow-canvas .output,
+.workflow-canvas .input {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: #e2e8f0;
+}
+
+.workflow-canvas .output + .control,
+.workflow-canvas .control + .input {
+  margin-top: 0.75rem;
+}
+
+.workflow-canvas .output-title,
+.workflow-canvas .input-title {
+  flex: 1;
+  color: #cbd5f5;
+  font-weight: 500;
+}
+
+.workflow-canvas .input-control,
+.workflow-canvas .control {
+  color: #e2e8f0;
+}
+
+.workflow-canvas .socket {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  border: 2px solid rgba(248, 250, 252, 0.9);
+  background: #38bdf8;
+  box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.9);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.workflow-canvas .socket.input {
+  background: #1d4ed8;
+  border-color: rgba(191, 219, 254, 0.95);
+}
+
+.workflow-canvas .socket:hover {
+  transform: scale(1.2);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.45);
+}
+
+.workflow-canvas svg.connection path {
+  stroke: rgba(56, 189, 248, 0.9);
+  stroke-width: 2.6px;
+  fill: none;
+}
+
+.workflow-canvas svg.connection.selected path {
+  stroke: rgba(248, 250, 252, 0.95);
 }
 
 .pipelet-node__event {
   margin-top: 0.5rem;
   padding: 0.35rem 0.5rem;
   border-radius: 0.5rem;
-  background: rgba(56, 189, 248, 0.15);
-  color: #0369a1;
+  background: rgba(14, 165, 233, 0.3);
+  color: #e0f2fe;
   font-size: 0.8rem;
   text-align: center;
 }
@@ -185,11 +290,11 @@ select {
   padding: 0.5rem 0.75rem;
   border-radius: 0.5rem;
   font-weight: 500;
+  color: #ffffff;
 }
 
 .status-message--success {
-  background: rgba(74, 222, 128, 0.2);
-  color: #14532d;
+  background: rgba(34, 197, 94, 0.45);
 }
 
 .status-message--error {


### PR DESCRIPTION
## Summary
- ensure success status messages remain readable on the dark header background
- add dedicated styling for the workflow canvas so loaded nodes, sockets, and connections are clearly visible
- adjust the pipelet event badge colors for better contrast on the redesigned canvas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2eecd098c8322ba7c854afe9b9688