### PR TITLE
Adjust workflow controls and token panel UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import {
 } from './components/WorkflowCanvas'
 import { TokenPanel } from './components/TokenPanel'
 import { createSeedPayload } from './seed'
+import { DownloadIcon, PlusIcon, SaveIcon, UploadIcon } from './components/icons'
 
 interface StatusMessage {
   type: 'success' | 'error'
@@ -245,21 +246,45 @@ function App(): JSX.Element {
           >
             {workflowOptions}
           </select>
-          <button type="button" onClick={() => selectedWorkflowId && handleWorkflowLoad(Number(selectedWorkflowId))} disabled={isLoading || !selectedWorkflowId}>
-            Laden
-          </button>
-          <button type="button" onClick={handleCreateWorkflow} disabled={isLoading}>
-            Neu
+          <button
+            type="button"
+            className="workflow-controls__icon-button"
+            title="Workflow laden"
+            aria-label="Workflow laden"
+            onClick={() => selectedWorkflowId && handleWorkflowLoad(Number(selectedWorkflowId))}
+            disabled={isLoading || !selectedWorkflowId}
+          >
+            <DownloadIcon />
           </button>
           <button
             type="button"
+            className="workflow-controls__icon-button"
+            title="Neuen Workflow anlegen"
+            aria-label="Neuen Workflow anlegen"
+            onClick={handleCreateWorkflow}
+            disabled={isLoading}
+          >
+            <PlusIcon />
+          </button>
+          <button
+            type="button"
+            className="workflow-controls__icon-button"
+            title="Workflow speichern"
+            aria-label="Workflow speichern"
             onClick={handleSaveWorkflow}
             disabled={isLoading || !activeWorkflow || !graph || !isDirty}
           >
-            Speichern
+            <SaveIcon />
           </button>
-          <button type="button" onClick={handleImportSeed} disabled={isLoading}>
-            Seed importieren
+          <button
+            type="button"
+            className="workflow-controls__icon-button"
+            title="Seed importieren"
+            aria-label="Seed importieren"
+            onClick={handleImportSeed}
+            disabled={isLoading}
+          >
+            <UploadIcon />
           </button>
         </div>
         {status && (

--- a/frontend/src/components/TokenPanel.tsx
+++ b/frontend/src/components/TokenPanel.tsx
@@ -88,7 +88,6 @@ export function TokenPanel(): JSX.Element {
   }, [isCollapsed])
 
   const maskedActiveToken = maskToken(getApiToken())
-  const collapseLabel = isCollapsed ? 'Ausklappen' : 'Einklappen'
   const collapseIcon = isCollapsed ? '▼' : '▲'
   const panelContentId = 'api-token-panel-content'
 
@@ -268,7 +267,6 @@ export function TokenPanel(): JSX.Element {
             onClick={() => setIsCollapsed((value) => !value)}
           >
             <span aria-hidden="true">{collapseIcon}</span>
-            {collapseLabel}
           </button>
           <button type="button" onClick={() => void refreshTokens()} disabled={isLoading}>
             Aktualisieren

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -1,0 +1,85 @@
+import type { SVGProps } from 'react'
+
+interface IconProps extends SVGProps<SVGSVGElement> {
+  size?: number
+}
+
+const baseIconProps = {
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.8,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  role: 'img' as const,
+}
+
+export function DownloadIcon({ size = 20, ...rest }: IconProps): JSX.Element {
+  return (
+    <svg
+      {...baseIconProps}
+      {...rest}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M12 3v11" />
+      <polyline points="7 11 12 16 17 11" />
+      <path d="M5 19h14" />
+    </svg>
+  )
+}
+
+export function PlusIcon({ size = 20, ...rest }: IconProps): JSX.Element {
+  return (
+    <svg
+      {...baseIconProps}
+      {...rest}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  )
+}
+
+export function SaveIcon({ size = 20, ...rest }: IconProps): JSX.Element {
+  return (
+    <svg
+      {...baseIconProps}
+      {...rest}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M6 4h11l3 3v13H6z" />
+      <path d="M6 4h11v6H6z" />
+      <rect x="9" y="14" width="6" height="6" rx="1" ry="1" />
+    </svg>
+  )
+}
+
+export function UploadIcon({ size = 20, ...rest }: IconProps): JSX.Element {
+  return (
+    <svg
+      {...baseIconProps}
+      {...rest}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M12 21V10" />
+      <polyline points="7 13 12 8 17 13" />
+      <path d="M5 5h14" />
+    </svg>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -57,8 +57,31 @@ body {
 .workflow-controls {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
+}
+
+.workflow-controls__icon-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0.45rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.75rem;
+  background: rgba(14, 165, 233, 0.85);
+  color: #0f172a;
+  box-shadow: 0 4px 10px rgba(14, 165, 233, 0.2);
+}
+
+.workflow-controls__icon-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.workflow-controls__icon-button:hover:not(:disabled) {
+  background: #0284c7;
+  box-shadow: 0 6px 14px rgba(2, 132, 199, 0.35);
 }
 
 .workflow-select {
@@ -104,6 +127,7 @@ select {
   grid-template-columns: 320px 1fr;
   gap: 1px;
   background: #cbd5f5;
+  min-height: 520px;
 }
 
 .palette-column {
@@ -115,6 +139,7 @@ select {
 .canvas-column {
   background: #e2e8f0;
   position: relative;
+  min-height: 520px;
 }
 
 .section-title {
@@ -654,15 +679,18 @@ select {
 .token-panel__collapse-button {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  justify-content: center;
   background: #e2e8f0;
   color: #0f172a;
   border: 1px solid rgba(148, 163, 184, 0.6);
-  padding: 0.4rem 0.75rem;
+  padding: 0.4rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.5rem;
 }
 
 .token-panel__collapse-button span {
-  font-size: 0.8rem;
+  font-size: 0.9rem;
 }
 
 .token-panel__collapse-button:hover:not(:disabled) {


### PR DESCRIPTION
## Summary
- replace the workflow header actions with compact icon-only buttons and add reusable SVG icons
- ensure the workflow canvas column keeps a consistent minimum height down to the log panel
- simplify the API token collapse control by removing the text label and updating its styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2fe3ce19883229812109a1e54ed25